### PR TITLE
Update src/Graphs.jl

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -24,10 +24,10 @@ module Graphs
 
     export read_edgelist, read_tgf, read_graphml
 
-    include(joinpath("Graphs", "src", "vertex.jl"))
-    include(joinpath("Graphs", "src", "edge.jl"))
-    include(joinpath("Graphs", "src", "graph.jl"))
-    include(joinpath("Graphs", "src", "advanced.jl"))
-    include(joinpath("Graphs", "src", "io.jl"))
-    include(joinpath("Graphs", "src", "show.jl"))
+    include("vertex.jl")
+    include("edge.jl")
+    include("graph.jl")
+    include("advanced.jl")
+    include("io.jl")
+    include("show.jl")
 end


### PR DESCRIPTION
`using Graphs` failed since it would try to load from `~/.julia/Graphs/src/Graphs/src/vertex.jl` which wasn't found.  Removing the extra paths fixed it for me.
