### PR TITLE
Signless Laplacian matrix

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -21,6 +21,7 @@ module Graphs
 
     export adjacency_matrix, degree_matrix, outdegree_matrix, indegree_matrix
     export distance_matrix, incidence_matrix, laplacian_matrix, laplacian
+    export signless_laplacian_matrix, signless_laplacian
 
     export read_edgelist, read_tgf, read_graphml
 

--- a/src/advanced.jl
+++ b/src/advanced.jl
@@ -187,3 +187,16 @@ function laplacian_matrix(g::DirectedGraph, direction::Symbol)
 end
 laplacian_matrix(g::DirectedGraph) = laplacian_matrix(g, :out)
 const laplacian = laplacian_matrix
+
+signless_laplacian_matrix(g::UndirectedGraph) = degree_matrix(g) + adjacency_matrix(g)
+function signless_laplacian_matrix(g::DirectedGraph, direction::Symbol)
+    if direction == :out
+        outdegree_matrix(g) + adjacency_matrix(g)
+    elseif direction == :in
+        indegree_matrix(g) + adjacency_matrix(g)
+    else
+        error("direction must be :out or :in")
+    end
+end
+signless_laplacian_matrix(g::DirectedGraph) = signless_laplacian_matrix(g, :out)
+const signless_laplacian = signless_laplacian_matrix

--- a/test/advanced.jl
+++ b/test/advanced.jl
@@ -44,7 +44,15 @@ L = [2 -1 0 0 -1 0;
      0 0 -1 3 -1 -1;
      -1 -1 0 -1 3 0;
      0 0 0 -1 0 1;]
+Q = [2 1 0 0 1 0;
+     1 3 1 0 1 0;
+     0 1 2 1 0 0;
+     0 0 1 3 1 1;
+     1 1 0 1 3 0;
+     0 0 0 1 0 1;]
 @assert isequal(laplacian(g), L)
+@assert isequal(signless_laplacian(g), Q)
+
 
 ##############################################################################
 #
@@ -71,5 +79,7 @@ g = UndirectedGraph(Set(v1, v2, v3), Set(e1, e2, e3))
 @assert isequal(adjacency_matrix(g), [0 1 1; 1 0 1; 1 1 0])
 @assert isequal(laplacian(g), degree_matrix(g) - adjacency_matrix(g))
 @assert isequal(laplacian(g), [2 -1 -1; -1 2 -1; -1 -1 2])
+@assert isequal(signless_laplacian(g), degree_matrix(g) + adjacency_matrix(g))
+@assert isequal(signless_laplacian(g), [2 1 1; 1 2 1; 1 1 2])
 
 @assert isweighted(g) == false


### PR DESCRIPTION
The signless Laplacian matrix is a slightly different version of the
Laplacian matrix and is used in some parts of spectral graph theory.
http://dx.doi.org/10.1016/j.laa.2007.01.009 describes it.
