### PR TITLE
Add basic dot file output

### DIFF
--- a/run_tests.jl
+++ b/run_tests.jl
@@ -1,10 +1,11 @@
-require("Graphs")
+require(joinpath("src","Graphs"))
 using Graphs
 
 my_tests = ["test/vertex.jl",
             "test/edge.jl",
             "test/graph.jl",
             "test/advanced.jl",
+            "test/dot.jl",
             "test/io.jl"]
 
 println("Running tests:")

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -25,10 +25,13 @@ module Graphs
 
     export read_edgelist, read_tgf, read_graphml
 
+    export to_dot
+
     include("vertex.jl")
     include("edge.jl")
     include("graph.jl")
     include("advanced.jl")
     include("io.jl")
     include("show.jl")
+    include("dot.jl")
 end

--- a/src/dot.jl
+++ b/src/dot.jl
@@ -1,0 +1,71 @@
+# Functions for representing graphs in GraphViz's dot format
+# http://www.graphviz.org/
+# http://www.graphviz.org/Documentation/dotguide.pdf
+# http://www.graphviz.org/pub/scm/graphviz2/doc/info/lang.html
+
+# Write the dot representation of a graph to a file by name.
+function to_dot(graph::AbstractGraph, filename::String)
+    f = open(filename,"w")
+        to_dot(graph, f)
+    close(f)
+
+end
+
+# Get the dot representation of a graph as a string.
+function to_dot(graph::AbstractGraph)
+    str = IOString()
+    to_dot(graph, str)
+    takebuf_string(str)
+end
+
+# Write the dot representation of a graph to a stream.
+function to_dot(graph::AbstractGraph, stream::IO)
+    write(stream, "$(graph_type_string(graph)) graphname {\n")
+    for edge in edges(graph)
+        write(stream, to_dot(edge))
+    end
+
+    for vertex in vertices(graph)
+        write(stream, to_dot(vertex))
+    end
+    write(stream, "}\n")
+    stream
+end
+
+function graph_type_string(graph::DirectedGraph)
+    "digraph"
+end
+
+function graph_type_string(graph::UndirectedGraph)
+    "graph"
+end
+
+# The dot representation of an edge.
+function to_dot(edge::Edge)
+    en = ends(edge)
+    state = start(en)
+    first, state = next(en,state)
+    second, state = next(en, state)
+    "$(id(first)) $(edge_op(edge)) $(id(second)) $(to_dot(attributes(edge)))\n"
+end
+
+function edge_op(edge::UndirectedEdge)
+    "--"
+end
+
+function edge_op(edge::DirectedEdge)
+    "->"
+end
+
+function to_dot(attrs::Dict{UTF8String,Any})
+    if isempty(attrs)
+        ""
+    else
+        f = (t::Tuple) -> "\"$(t[1])\"=\"$(t[2])\""
+        string("[",join(map(f,collect(attrs)),","),"]")
+    end
+end
+
+function to_dot(Vertex)
+    ""
+end

--- a/test/data/graph1.dot
+++ b/test/data/graph1.dot
@@ -1,0 +1,5 @@
+digraph graphname {
+1 -> 2 
+2 -> 3 
+1 -> 3 
+}

--- a/test/dot.jl
+++ b/test/dot.jl
@@ -1,0 +1,49 @@
+
+# A vertex with no attributes has a blank dot representation.
+let v1 = Vertex(1)
+  @assert to_dot(v1) == ""
+end
+
+# A directed edge with no attributes:
+let e1 = DirectedEdge(1,2)
+    @assert to_dot(e1) == "1 -> 2 \n"
+end
+
+# An undirected edge with no attributes:
+let e1 = UndirectedEdge(1,2)
+    @assert contains(["1 -- 2 \n","2 -- 1 \n"],to_dot(e1))
+end
+
+# Attributes get layed out correctly
+# I'm assuming here that all the graph bits have the same sort of attributes
+# No attributes are layed out for now.
+let v1 = Vertex(1)
+    attr_type = typeof(attributes(v1))
+    attrs = attr_type()
+    @assert to_dot(attrs) == ""
+
+    attrs["foo"] = "bar"
+    @assert to_dot(attrs) == "[\"foo\"=\"bar\"]"
+
+    attrs["baz"] = "qux"
+    @assert contains(["[\"foo\"=\"bar\",\"baz\"=\"qux\"]",
+                      "[\"baz\"=\"qux\",\"foo\"=\"bar\"]"], to_dot(attrs))
+end
+
+let g=UndirectedGraph()
+    @assert to_dot(g) == "graph graphname {\n}\n"
+end
+
+let g=DirectedGraph()
+    @assert to_dot(g) == "digraph graphname {\n}\n"
+end
+
+# I don't know a clean way to make this work, as the dot output edge order changes with every run.
+#let g=read_edgelist(joinpath("test", "data", "graph1.edgelist"))
+#    f = open(joinpath("test","data","graph1.dot"))
+#    str = readall(f)
+#    close(f)
+#    println(str)
+#    println(to_dot(g))
+#    @assert to_dot(g) == str
+#end


### PR DESCRIPTION
This pull request is an initial solution for issue #6, visualizing graphs.  It only produces dot format files, which can then be passed to dot/graphviz externally.  Not exactly saying plot(g) and having a nice interactive window pop up, but still useful.

I wasn't able to get the tests to run without changing require("Graphs") to require("src/Graphs").  I think my local Pkg-added Graphs package was overriding the local copy.  I will take that out if it is wrong.
