### PR TITLE
Write Vertex attributes and add plot function

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -26,6 +26,7 @@ module Graphs
     export read_edgelist, read_tgf, read_graphml
 
     export to_dot
+    export plot
 
     include("vertex.jl")
     include("edge.jl")

--- a/src/dot.jl
+++ b/src/dot.jl
@@ -66,6 +66,17 @@ function to_dot(attrs::Dict{UTF8String,Any})
     end
 end
 
-function to_dot(Vertex)
-    ""
+function to_dot(v::Vertex)
+    attrs = attributes(v)
+    if isempty(attrs)
+        ""
+    else
+        "$(id(v)) $(to_dot(attrs))\n"
+    end
+end
+
+function plot(g::AbstractGraph)
+    stdin, proc = writesto(`neato -Tx11`)
+    to_dot(g, stdin)
+    close(stdin)
 end

--- a/test/dot.jl
+++ b/test/dot.jl
@@ -15,15 +15,13 @@ let e1 = UndirectedEdge(1,2)
 end
 
 # Attributes get layed out correctly
-# I'm assuming here that all the graph bits have the same sort of attributes
-# No attributes are layed out for now.
 let v1 = Vertex(1)
-    attr_type = typeof(attributes(v1))
-    attrs = attr_type()
+    attrs = attributes(v1)
     @assert to_dot(attrs) == ""
 
     attrs["foo"] = "bar"
     @assert to_dot(attrs) == "[\"foo\"=\"bar\"]"
+    @assert to_dot(v1) == "1 [\"foo\"=\"bar\"]\n"
 
     attrs["baz"] = "qux"
     @assert contains(["[\"foo\"=\"bar\",\"baz\"=\"qux\"]",


### PR DESCRIPTION
Hello,  I'm putting that plot function in and writing vertex attributes, which I had forgotten.  I think the plot function is worth having, even if it won't work for people without graphviz installed.  If it's ever made flexible and robust, it's probably worth pulling out to a package of its own, where it can have graphviz as a dependency without burdening the main graph stuff.

I also have some work on random graphs, an erdos_renyi generator and a watts_strogatz generator, for a future pull request, maybe tomorrow.  
