### PR TITLE
Write attributes in to_dot

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -38,7 +38,7 @@ module Graphs
         simple_adjlist, adjlist,
         
         # incidence_list
-        GenericIncidenceList, SimpleIncidenceList, VectorIncidenceList, IncidenceList, 
+        GenericIncidenceList, SimpleIncidenceList, IncidenceList, 
         simple_inclist, inclist,
         
         # graph

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -24,10 +24,11 @@ module Graphs
         is_directed, is_mutable, vertex_index, edge_index,
         num_vertices, vertices, num_edges, edges, 
         out_degree, out_neighbors, out_edges,
-        in_degree, in_neighbors, in_edges,        
+        in_degree, in_neighbors, in_edges,   
+        attributes,     
         
         # common
-        KeyVertex, Edge, WeightedEdge, ExVertex, ExEdge, 
+        KeyVertex, Edge, WeightedEdge, ExVertex, ExEdge, AttributeDict,
         collect_edges, collect_weighted_edges,
         
         add_edge!, add_vertex!, add_edges!, add_vertices!,
@@ -37,7 +38,7 @@ module Graphs
         simple_adjlist, adjlist,
         
         # incidence_list
-        GenericIncidenceList, SimpleIncidenceList, IncidenceList, 
+        GenericIncidenceList, SimpleIncidenceList, VectorIncidenceList, IncidenceList, 
         simple_inclist, inclist,
         
         # graph

--- a/src/common.jl
+++ b/src/common.jl
@@ -1,5 +1,6 @@
 # Common facilities
 
+typealias AttributeDict Dict{UTF8String, Any}
 
 #################################################
 #
@@ -19,12 +20,13 @@ vertex_index(v::KeyVertex) = v.index
 type ExVertex
     index::Int
     label::UTF8String
-    attributes::Dict{UTF8String,Any}
+    attributes::AttributeDict
     
-    ExVertex(i::Int, label::String) = new(i, label, Dict{UTF8String,Any}())    
+    ExVertex(i::Int, label::String) = new(i, label, AttributeDict())    
 end
 
 vertex_index(v::ExVertex) = v.index
+attributes(v::ExVertex, g::AbstractGraph) = v.attributes
 
 #################################################
 #
@@ -53,21 +55,23 @@ type ExEdge{V}
     index::Int
     source::V
     target::V
-    attributes::Dict{UTF8String,Any}
+    attributes::AttributeDict
     
     function ExEdge(idx::Int, s::V, t::V)
-        attrs = Dict{UTF8String,Any}()
+        attrs = AttributeDict()
         new(idx, s, t, attrs)
     end
     
-    function ExEdge(idx::Int, s::V, t::V, attrs::Dict{UTF8String,Any})
-        attrs = Dict{UTF8String,Any}()
+    function ExEdge(idx::Int, s::V, t::V, attrs::AttributeDict)
         new(idx, s, t, attrs)
     end
 end
 
 source(e::ExEdge) = e.source
 target(e::ExEdge) = e.target
+source{V}(e::ExEdge{V}, g::AbstractGraph{V}) = e.source
+target{V}(e::ExEdge{V}, g::AbstractGraph{V}) = e.target
+attributes(e::ExEdge, g::AbstractGraph) = e.attributes
 
 edge_index(e::ExEdge) = e.index
 revedge{V}(e::ExEdge{V}) = ExEdge{V}(e.index, e.target, e.source, e.attributes)

--- a/test/dot.jl
+++ b/test/dot.jl
@@ -9,19 +9,77 @@ function xor(a, b)
 	(a || b) && !(a && b)
 end
 
-# Attributes get layed out correctly
-#let v1 = Vertex(1)
-#    attrs = attributes(v1)
-#    @test to_dot(attrs) == ""
-#
-#    attrs["foo"] = "bar"
-#    @test to_dot(attrs) == "[\"foo\"=\"bar\"]"
-#    @test to_dot(v1) == "1 [\"foo\"=\"bar\"]\n"
-#
-#    attrs["baz"] = "qux"
-#    @test contains(["[\"foo\"=\"bar\",\"baz\"=\"qux\"]",
-#                      "[\"baz\"=\"qux\",\"foo\"=\"bar\"]"], to_dot(attrs))
-#end
+# Vertex attributes get layed out correctly
+let g=inclist(ExVertex, is_directed=false)
+    add_vertex!(g, ExVertex(1, "label1"))
+    add_vertex!(g, ExVertex(2, "label2"))
+    add_edge!(g, vertices(g)[1], vertices(g)[2])
+    attrs = attributes(vertices(g)[1], g)
+
+    @test to_dot(attrs) == ""
+
+    attrs["foo"] = "bar"
+    @test to_dot(attrs) == "[\"foo\"=\"bar\"]"
+
+    attrs["baz"] = "qux"
+    # Below here we do some messing around so as not to assert on dict iteration order.
+    @test contains(["[\"foo\"=\"bar\",\"baz\"=\"qux\"]",
+                      "[\"baz\"=\"qux\",\"foo\"=\"bar\"]"], to_dot(attrs))
+
+    sp = split(to_dot(g), "\n")
+    @test contains(sp, "1 [\"foo\"=\"bar\",\"baz\"=\"qux\"]") ||
+          contains(sp, "1 [\"baz\"=\"qux\",\"foo\"=\"bar\"]")
+end
+
+typealias ExEIncidenceList{V} GenericIncidenceList{V, ExEdge{V}, Vector{V}, Vector{Vector{ExEdge{V}}}}
+typealias G ExEIncidenceList{ExVertex}
+function Graphs.add_vertex!(g::G, v::ExVertex)
+    nv::Int = num_vertices(g)
+    iv::Int = vertex_index(v)
+    if iv != nv + 1
+        throw(ArgumentError("Invalid vertex index."))
+    end        
+    
+    push!(g.vertices, v)
+    push!(g.inclist, Array(ExEdge,0))
+    v
+end
+function Graphs.add_edge!{V}(g::G, u::V, v::V)
+    nv::Int = num_vertices(g)
+    ui::Int = vertex_index(u)
+    vi::Int = vertex_index(v)
+    
+    if !(ui >= 1 && ui <= nv && vi >= 1 && vi <= nv)
+        throw(ArgumentError("u or v is not a valid vertex."))
+    end
+    ei::Int = (g.nedges += 1)
+    e = ExEdge{V}(ei, u, v)
+    push!(g.inclist[ui], e)
+    
+    if !g.is_directed
+        push!(g.inclist[vi], ExEdge{V}(ei, v, u, e.attributes))
+    end
+end
+# Edge attributes get layed out correctly
+let 
+    g = G(false, Array(ExVertex, 0), 0, Array(Vector{ExEdge{ExVertex}},0))
+    add_vertex!(g, ExVertex(1, "label1"))
+    add_vertex!(g, ExVertex(2, "label2"))
+    
+    add_edge!(g, vertices(g)[1], vertices(g)[2])
+
+    e = out_edges(vertices(g)[2], g)[1]
+
+    attrs = attributes(e, g)
+    attrs["foo"] = "bar"
+    @test to_dot(attrs) == "[\"foo\"=\"bar\"]"
+
+    attrs["baz"] = "qux"
+
+    sp = split(to_dot(g), "\n")
+    @test contains(sp, "1 -- 2 [\"foo\"=\"bar\",\"baz\"=\"qux\"]") ||
+          contains(sp, "1 -- 2 [\"baz\"=\"qux\",\"foo\"=\"bar\"]")
+end
 
 let g=simple_graph(0, is_directed=false)
     @test to_dot(g) == "graph graphname {\n}\n"
@@ -41,7 +99,7 @@ let g=simple_adjlist(3)
     @test has_match(r"1 -> 3", str)
     @test has_match(r"2 -> 3", str)
     @test has_match(r"3 -> 2", str)
-    @test !has_match(r"--", str)    
+    @test !has_match(r"--", str)
 end
 
 let g=simple_adjlist(3, is_directed=false)


### PR DESCRIPTION
Hello,

This pull request adds attribute writing capability to dot.jl.

I expect there to be a method `attributes(e::E, g::G)` or `attributes(v::V, g::G)`, for edges and vectors respectively.  I added that method for ExVertex and ExEdge, and also fixed what I'm pretty sure was a bug in the ExEdge constructor, where it was ignoring the passed in dict of attributes.

I add the AttributeDict alias so it's easier to make a compatible graph from the outside.  

As an aside, I did a lot of wishing that we had real interface types while writing this.
