### PR TITLE
Fix cyclic test for graphs with ExVert vertices.

### DIFF
--- a/src/depth_first_visit.jl
+++ b/src/depth_first_visit.jl
@@ -12,33 +12,33 @@ end
 
 function depth_first_visit_impl!(
     graph::AbstractGraph,           # the graph
-    stack,                          # an (initialized) stack of vertex 
+    stack,                          # an (initialized) stack of vertex
     colormap::Vector{Int},          # an (initialized) color-map to indicate status of vertices
     visitor::AbstractGraphVisitor)  # the visitor
-        
-    while !isempty(stack)        
+
+    while !isempty(stack)
         u, unbs, tstate = pop!(stack)
         found_new_vertex = false
-        
+
         while !done(unbs, tstate) && !found_new_vertex
             v, tstate = next(unbs, tstate)
             v_color = colormap[vertex_index(v, graph)]
             examine_neighbor!(visitor, u, v, v_color)
-            
+
             if v_color == 0
                 found_new_vertex = true
                 colormap[vertex_index(v, graph)] = 1
                 if !discover_vertex!(visitor, v)
                     return
-                end                
+                end
                 push!(stack, (u, unbs, tstate))
-                
+
                 open_vertex!(visitor, v)
                 vnbs = out_neighbors(v, graph)
-                push!(stack, (v, vnbs, start(vnbs)))                
-            end 
-        end        
-        
+                push!(stack, (v, vnbs, start(vnbs)))
+            end
+        end
+
         if !found_new_vertex
             close_vertex!(visitor, u)
             colormap[vertex_index(u, graph)] = 2
@@ -47,27 +47,27 @@ function depth_first_visit_impl!(
 end
 
 function traverse_graph{V,E}(
-    graph::AbstractGraph{V,E}, 
+    graph::AbstractGraph{V,E},
     alg::DepthFirst,
-    s::V, 
-    visitor::AbstractGraphVisitor; 
+    s::V,
+    visitor::AbstractGraphVisitor;
     colormap = nothing)
-    
+
     @graph_requires graph adjacency_list vertex_map
-    
+
     if colormap == nothing
         colormap = zeros(Int, num_vertices(graph))
     end
-    
+
     colormap[vertex_index(s, graph)] = 1
     if !discover_vertex!(visitor, s)
         return
     end
-    
+
     snbs = out_neighbors(s, graph)
-    sstate = start(snbs)    
+    sstate = start(snbs)
     stack = [(s, snbs, sstate)]
-    
+
     depth_first_visit_impl!(graph, stack, colormap, visitor)
 end
 
@@ -81,7 +81,7 @@ end
 # Test whether a graph is cyclic
 
 type DFSCyclicTestVisitor <: AbstractGraphVisitor
-    found_cycle::Bool    
+    found_cycle::Bool
     DFSCyclicTestVisitor() = new(false)
 end
 
@@ -91,23 +91,23 @@ function examine_neighbor!{V}(vis::DFSCyclicTestVisitor, u::V, v::V, color::Int)
     end
 end
 
-discover_vertex!(vis::DFSCyclicTestVisitor, v) = !vis.found_cycle    
+discover_vertex!(vis::DFSCyclicTestVisitor, v) = !vis.found_cycle
 
 function test_cyclic_by_dfs(graph::AbstractGraph)
     @graph_requires graph vertex_list adjacency_list vertex_map
-    
-    cmap = zeros(Int, num_vertices(graph))        
+
+    cmap = zeros(Int, num_vertices(graph))
     visitor = DFSCyclicTestVisitor()
-    
+
     for s in vertices(graph)
-        if cmap[s] == 0
+        if cmap[vertex_index(s, graph)] == 0
             traverse_graph(graph, DepthFirst(), s, visitor, colormap=cmap)
         end
-        
+
         if visitor.found_cycle
             return true
         end
-    end    
+    end
     return false
 end
 
@@ -115,7 +115,7 @@ end
 
 type TopologicalSortVisitor{V} <: AbstractGraphVisitor
     vertices::Vector{V}
-    
+
     function TopologicalSortVisitor(n::Int)
         vs = Array(Int, 0)
         sizehint(vs, n)
@@ -136,16 +136,16 @@ end
 
 function topological_sort_by_dfs{V}(graph::AbstractGraph{V})
     @graph_requires graph vertex_list adjacency_list vertex_map
-    
+
     cmap = zeros(Int, num_vertices(graph))
     visitor = TopologicalSortVisitor{V}(num_vertices(graph))
-    
+
     for s in vertices(graph)
         if cmap[s] == 0
             traverse_graph(graph, DepthFirst(), s, visitor, colormap=cmap)
         end
-    end 
-        
+    end
+
     reverse(visitor.vertices)
 end
 

--- a/test/dfs.jl
+++ b/test/dfs.jl
@@ -3,26 +3,25 @@
 using Graphs
 using Base.Test
 
-g = simple_adjlist(6)
+acyclic = [(1,2) (1,3) (1,6) (2,4) (2,5) (3,5) (3,6)]
+cyclic  = [(1,2) (1,3) (1,6) (2,4) (2,5) (3,5) (3,6) (5,1)]
 
-add_edge!(g, 1, 2)
-add_edge!(g, 1, 3)
-add_edge!(g, 1, 6)
-add_edge!(g, 2, 4)
-add_edge!(g, 2, 5)
-add_edge!(g, 3, 5)
-add_edge!(g, 3, 6)
+g = simple_adjlist(6)
+map((edg) -> add_edge!(g, edg[1], edg[2]), acyclic)
 
 g2 = simple_adjlist(6)
+map((edg) -> add_edge!(g2, edg[1], edg[2]), cyclic)
 
-add_edge!(g2, 1, 2)
-add_edge!(g2, 1, 3)
-add_edge!(g2, 1, 6)
-add_edge!(g2, 2, 4)
-add_edge!(g2, 2, 5)
-add_edge!(g2, 3, 5)
-add_edge!(g2, 3, 6)
-add_edge!(g2, 5, 1)
+
+gEx = graph(ExVertex, ExEdge{ExVertex}, is_directed = true)
+map((x) -> add_vertex!(gEx, "edge:" * string(x)), 1:6)
+V = vertices(gEx)
+map((edg) -> add_edge!(gEx, V[edg[1]], V[edg[2]]), acyclic)
+
+gEx2 = graph(ExVertex, ExEdge{ExVertex}, is_directed = true)
+map((x) -> add_vertex!(gEx2, "edge:" * string(x)), 1:6)
+V2 = vertices(gEx2)
+map((edg) -> add_edge!(gEx2, V2[edg[1]], V2[edg[2]]), cyclic)
 
 # DFS traversal
 
@@ -36,6 +35,11 @@ vs2 = visited_vertices(g2, DepthFirst(), 1)
 
 @assert test_cyclic_by_dfs(g) == false
 @assert test_cyclic_by_dfs(g2) == true
+
+# Cyclic test with Extended Graph types
+
+@assert test_cyclic_by_dfs(gEx) == false
+@assert test_cyclic_by_dfs(gEx2) == true
 
 # Topological sort
 


### PR DESCRIPTION
The test_cyclic_by_dfs method previously assumed that the graph being passed
in had vertices of type int. This caused an exception to be thrown when trying
to run test_cyclic_by_dfs on graphs with ExVert vertices.

This commit resolves the issue.
