### PR TITLE
Adding cycle tests for undirected graphs.

### DIFF
--- a/src/breadth_first_visit.jl
+++ b/src/breadth_first_visit.jl
@@ -11,72 +11,73 @@ end
 
 function breadth_first_visit_impl!(
     graph::AbstractGraph,   # the graph
-    queue,                  # an (initialized) queue that stores the active vertices    
+    queue,                  # an (initialized) queue that stores the active vertices
     colormap::Vector{Int},          # an (initialized) color-map to indicate status of vertices
     visitor::AbstractGraphVisitor)  # the visitor
-            
+
     while !isempty(queue)
         u = dequeue!(queue)
         open_vertex!(visitor, u)
-        
+
         for v in out_neighbors(u, graph)
             v_color::Int = colormap[v]
-            examine_neighbor!(visitor, u, v, v_color)
-                        
+            # TODO: Incorporate edge colors to BFS
+            examine_neighbor!(visitor, u, v, v_color, -1)
+
             if v_color == 0
                 colormap[vertex_index(v, graph)] = 1
                 if !discover_vertex!(visitor, v)
                     return
                 end
                 enqueue!(queue, v)
-            end                
+            end
         end
-        
+
         colormap[vertex_index(u, graph)] = 2
-        close_vertex!(visitor, u)            
-    end    
+        close_vertex!(visitor, u)
+    end
     nothing
 end
 
 
 function traverse_graph{V,E}(
-    graph::AbstractGraph{V,E}, 
+    graph::AbstractGraph{V,E},
     alg::BreadthFirst,
-    s::V, 
-    visitor::AbstractGraphVisitor; 
+    s::V,
+    visitor::AbstractGraphVisitor;
     colormap = nothing)
-    
+
     @graph_requires graph adjacency_list vertex_map
-    
+
     if colormap == nothing
         colormap = zeros(Int, num_vertices(graph))
     end
     que = queue(V)
-    
+
     colormap[vertex_index(s, graph)] = 1
     if !discover_vertex!(visitor, s)
         return
     end
     enqueue!(que, s)
-    
+
     breadth_first_visit_impl!(graph, que, colormap, visitor)
 end
 
 
 function traverse_graph{V,E}(
-    graph::AbstractGraph{V,E}, 
+    graph::AbstractGraph{V,E},
     alg::BreadthFirst,
-    sources::AbstractVector{V}, 
-    visitor::AbstractGraphVisitor; 
+    sources::AbstractVector{V},
+    visitor::AbstractGraphVisitor;
     colormap = nothing)
-    
+
     @graph_requires graph adjacency_list vertex_map
-    
+
     if colormap == nothing
         colormap = zeros(Int, num_vertices(graph))
     end
     que = queue(V)
-    
+
     for s in sources
         colormap[vertex_index(s, graph)] = 1
         if !discover_vertex!(visitor, s)
@@ -84,7 +85,7 @@ function traverse_graph{V,E}(
         end
         enqueue!(que, s)
     end
-    
+
     breadth_first_visit_impl!(graph, que, colormap, visitor)
 end
 
@@ -101,8 +102,8 @@ type GDistanceVisitor <: AbstractGraphVisitor
     dists::Vector{Int}
 end
 
-function examine_neighbor!(visitor::GDistanceVisitor, u, v, color::Int)
-    if color == 0
+function examine_neighbor!(visitor::GDistanceVisitor, u, v, vcolor::Int, ecolor::Int)
+    if vcolor == 0
         dists = visitor.dists
         dists[vertex_index(v)] = dists[vertex_index(u)] + 1
     end
@@ -110,22 +111,22 @@ end
 
 function gdistances!{V,E,DMap}(graph::AbstractGraph{V,E}, s::V, dists::DMap)
     visitor = GDistanceVisitor(dists)
-    dists[vertex_index(s, graph)] = 0  
+    dists[vertex_index(s, graph)] = 0
     traverse_graph(graph, BreadthFirst(), s, visitor)
-    dists                
+    dists
 end
 
 function gdistances!{V,E,DMap}(graph::AbstractGraph{V,E}, sources::AbstractVector{V}, dists::DMap)
     visitor = GDistanceVisitor(dists)
-    for s in sources        
-        dists[vertex_index(s, graph)] = 0  
+    for s in sources
+        dists[vertex_index(s, graph)] = 0
     end
     traverse_graph(graph, BreadthFirst(), sources, visitor)
-    dists                
+    dists
 end
 
 function gdistances(graph::AbstractGraph, sources; defaultdist::Int=-1)
-    dists = fill(defaultdist, num_vertices(graph))    
+    dists = fill(defaultdist, num_vertices(graph))
     gdistances!(graph, sources, dists)
 end
 

--- a/src/breadth_first_visit.jl
+++ b/src/breadth_first_visit.jl
@@ -45,13 +45,10 @@ function traverse_graph{V,E}(
     alg::BreadthFirst,
     s::V,
     visitor::AbstractGraphVisitor;
-    colormap = nothing)
+    colormap = zeros(Int, num_vertices(graph)))
 
     @graph_requires graph adjacency_list vertex_map
 
-    if colormap == nothing
-        colormap = zeros(Int, num_vertices(graph))
-    end
     que = queue(V)
 
     colormap[vertex_index(s, graph)] = 1
@@ -69,13 +66,10 @@ function traverse_graph{V,E}(
     alg::BreadthFirst,
     sources::AbstractVector{V},
     visitor::AbstractGraphVisitor;
-    colormap = nothing)
+    colormap = zeros(Int, num_vertices(graph)))
 
     @graph_requires graph adjacency_list vertex_map
 
-    if colormap == nothing
-        colormap = zeros(Int, num_vertices(graph))
-    end
     que = queue(V)
 
     for s in sources

--- a/src/connected_components.jl
+++ b/src/connected_components.jl
@@ -8,14 +8,14 @@
 
 function connected_components{V}(graph::AbstractGraph{V})
     @graph_requires graph vertex_list vertex_map adjacency_list
-    
+
     if is_directed(graph)
         throw(ArgumentError("graph must be undirected."))
     end
-    
+
     cmap = zeros(Int, num_vertices(graph))
     components = Array(Vector{V}, 0)
-    
+
     for v in vertices(graph)
         if cmap[vertex_index(v, graph)] == 0
             visitor = VertexListVisitor{V}(0)
@@ -23,7 +23,7 @@ function connected_components{V}(graph::AbstractGraph{V})
             push!(components, visitor.vertices)
         end
     end
-    
+
     components
 end
 
@@ -36,7 +36,7 @@ end
 function strongly_connected_components_recursive{V}(graph::AbstractGraph{V})
     """
     Recursively compute the strongly connected components of a directed graph.
-    
+
     Adapted from
     http://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
     on April 29, 2013.
@@ -83,7 +83,7 @@ function strongly_connected_components_recursive{V}(graph::AbstractGraph{V})
                 end
             end
             push!(components, component)
-        end 
+        end
     end
 
     for v in vertices(graph)
@@ -101,7 +101,7 @@ type TarjanVisitor{V} <: AbstractGraphVisitor
     index        :: Array{Int}
     components   :: Array{Vector{V}}
 
-    function TarjanVisitor(graph::AbstractGraph) 
+    function TarjanVisitor(graph::AbstractGraph)
         v_idx  = v -> vertex_index(v, graph)
         stack  = Array(V, 0)
         index  = zeros(Int, num_vertices(graph))
@@ -111,13 +111,13 @@ type TarjanVisitor{V} <: AbstractGraphVisitor
         new(v_idx, stack, lowlink, index, components)
     end
 end
-function discover_vertex!(vis::TarjanVisitor, v) 
+function discover_vertex!(vis::TarjanVisitor, v)
     vis.index[vis.vertex_index(v)] = length(vis.stack) + 1
     push!(vis.lowlink, length(vis.stack) + 1)
     push!(vis.stack, v)
     true
 end
-function examine_neighbor!(vis::TarjanVisitor, v, w, w_color::Int)
+function examine_neighbor!(vis::TarjanVisitor, v, w, w_color::Int, e_color::Int)
     if w_color == 1 # 1 means added seen, but not explored
         while vis.index[vis.vertex_index(w)] < vis.lowlink[end]
             pop!(vis.lowlink)
@@ -126,12 +126,12 @@ function examine_neighbor!(vis::TarjanVisitor, v, w, w_color::Int)
 end
 function close_vertex!(vis::TarjanVisitor, v)
     v_idx = vis.vertex_index(v)
-    if vis.index[v_idx] == vis.lowlink[end] 
+    if vis.index[v_idx] == vis.lowlink[end]
         component = vis.stack[vis.index[v_idx]:]
         splice!(vis.stack, vis.index[v_idx]:length(vis.stack))
         pop!(vis.lowlink)
         push!(vis.components, component)
-    end 
+    end
 end
 
 function strongly_connected_components{V}(graph::AbstractGraph{V})
@@ -142,7 +142,7 @@ function strongly_connected_components{V}(graph::AbstractGraph{V})
     julia> add_edge!(g, 2, 3)
     julia> add_edge!(g, 3, 1)
     julia> add_edge!(g, 4, 1)
-    
+
     julia> strongly_connected_components(g)
     2-element Array{Int64,1} Array:
      [1, 2, 3]
@@ -151,18 +151,18 @@ function strongly_connected_components{V}(graph::AbstractGraph{V})
     Adapated from
     http://code.activestate.com/recipes/578507-strongly-connected-components-of-a-directed-graph/
     on April 30, 2013.
-    
+
     """
-    
+
     @graph_requires graph vertex_list vertex_map adjacency_list
 
     cmap = zeros(Int, num_vertices(graph))
     components = Array(Vector{V}, 0)
-    
+
     for v in vertices(graph)
         if cmap[vertex_index(v, graph)] == 0 # 0 means not visited yet
             visitor = TarjanVisitor{V}(graph)
-            traverse_graph(graph, DepthFirst(), v, visitor, colormap=cmap)
+            traverse_graph(graph, DepthFirst(), v, visitor, vertexcolormap=cmap)
             for component in visitor.components
                 push!(components, component)
             end

--- a/src/depth_first_visit.jl
+++ b/src/depth_first_visit.jl
@@ -10,65 +10,77 @@
 type DepthFirst <: AbstractGraphVisitAlgorithm
 end
 
-function depth_first_visit_impl!(
-    graph::AbstractGraph,           # the graph
+function depth_first_visit_impl!{V,E}(
+    graph::AbstractGraph{V,E},      # the graph
     stack,                          # an (initialized) stack of vertex
-    colormap::Vector{Int},          # an (initialized) color-map to indicate status of vertices
+    vertexcolormap::Vector{Int},    # an (initialized) color-map to indicate status of vertices
+    edgecolormap::Vector{Int},      # an (initialized) color-map to indicate status of edges
     visitor::AbstractGraphVisitor)  # the visitor
 
     while !isempty(stack)
-        u, unbs, tstate = pop!(stack)
+        u, uegs, tstate = pop!(stack)
         found_new_vertex = false
 
-        while !done(unbs, tstate) && !found_new_vertex
-            v, tstate = next(unbs, tstate)
-            v_color = colormap[vertex_index(v, graph)]
-            examine_neighbor!(visitor, u, v, v_color)
+        while !done(uegs, tstate) && !found_new_vertex
+            v_edge, tstate = next(uegs, tstate)
+            v = v_edge.target
+            v_color = vertexcolormap[vertex_index(v, graph)]
+            e_color = edgecolormap[edge_index(v_edge, graph)]
+            examine_neighbor!(visitor, u, v, v_color, e_color)
+
+            if e_color == 0
+                edgecolormap[edge_index(v_edge, graph)] = 1
+            end
 
             if v_color == 0
                 found_new_vertex = true
-                colormap[vertex_index(v, graph)] = 1
+                vertexcolormap[vertex_index(v, graph)] = 1
                 if !discover_vertex!(visitor, v)
                     return
                 end
-                push!(stack, (u, unbs, tstate))
+                push!(stack, (u, uegs, tstate))
 
                 open_vertex!(visitor, v)
-                vnbs = out_neighbors(v, graph)
-                push!(stack, (v, vnbs, start(vnbs)))
+                vegs = out_edges(v, graph)
+                push!(stack, (v, vegs, start(vegs)))
             end
         end
 
         if !found_new_vertex
             close_vertex!(visitor, u)
-            colormap[vertex_index(u, graph)] = 2
+            vertexcolormap[vertex_index(u, graph)] = 2
         end
     end
 end
 
-function traverse_graph{V,E}(
-    graph::AbstractGraph{V,E},
+function traverse_graph{V,G <: AbstractGraph}(
+    graph::G,
     alg::DepthFirst,
     s::V,
     visitor::AbstractGraphVisitor;
-    colormap = nothing)
+    vertexcolormap = nothing,
+    edgecolormap = nothing)
 
-    @graph_requires graph adjacency_list vertex_map
+    @graph_requires graph incidence_list vertex_map
 
-    if colormap == nothing
-        colormap = zeros(Int, num_vertices(graph))
+    if vertexcolormap == nothing
+        vertexcolormap = zeros(Int, num_vertices(graph))
     end
 
-    colormap[vertex_index(s, graph)] = 1
+    if edgecolormap == nothing
+        edgecolormap = zeros(Int, num_edges(graph))
+    end
+
+    vertexcolormap[vertex_index(s, graph)] = 1
     if !discover_vertex!(visitor, s)
         return
     end
 
-    snbs = out_neighbors(s, graph)
-    sstate = start(snbs)
-    stack = [(s, snbs, sstate)]
+    segs = out_edges(s, graph)
+    sstate = start(segs)
+    stack = [(s, segs, sstate)]
 
-    depth_first_visit_impl!(graph, stack, colormap, visitor)
+    depth_first_visit_impl!(graph, stack, vertexcolormap, edgecolormap, visitor)
 end
 
 
@@ -82,30 +94,33 @@ end
 
 type DFSCyclicTestVisitor <: AbstractGraphVisitor
     found_cycle::Bool
+
     DFSCyclicTestVisitor() = new(false)
 end
 
-function examine_neighbor!{V}(vis::DFSCyclicTestVisitor, u::V, v::V, color::Int)
-    if color == 1
+function examine_neighbor!{V}(
+    vis::DFSCyclicTestVisitor,
+    u::V,
+    v::V,
+    vcolor::Int,
+    ecolor::Int)
+
+    if vcolor == 1 && ecolor == 0
         vis.found_cycle = true
     end
 end
 
 discover_vertex!(vis::DFSCyclicTestVisitor, v) = !vis.found_cycle
 
-function test_cyclic_by_dfs(graph::AbstractGraph)
-    @graph_requires graph vertex_list adjacency_list vertex_map
-    
-    if !is_directed(graph)
-        throw(ArgumentError("test_cyclic_by_dfs: The input graph must be directed."))
-    end
+function test_cyclic_by_dfs{G <: AbstractGraph}(graph::G)
+    @graph_requires graph vertex_list incidence_list vertex_map
 
     cmap = zeros(Int, num_vertices(graph))
     visitor = DFSCyclicTestVisitor()
 
     for s in vertices(graph)
         if cmap[vertex_index(s, graph)] == 0
-            traverse_graph(graph, DepthFirst(), s, visitor, colormap=cmap)
+            traverse_graph(graph, DepthFirst(), s, visitor, vertexcolormap=cmap)
         end
 
         if visitor.found_cycle
@@ -128,8 +143,8 @@ type TopologicalSortVisitor{V} <: AbstractGraphVisitor
 end
 
 
-function examine_neighbor!{V}(visitor::TopologicalSortVisitor{V}, u::V, v::V, color::Int)
-    if color == 1
+function examine_neighbor!{V}(visitor::TopologicalSortVisitor{V}, u::V, v::V, vcolor::Int, ecolor::Int)
+    if vcolor == 1
         throw(ArgumentError("The input graph contains at least one loop."))
     end
 end
@@ -139,26 +154,17 @@ function close_vertex!{V}(visitor::TopologicalSortVisitor{V}, v::V)
 end
 
 function topological_sort_by_dfs{V}(graph::AbstractGraph{V})
-    @graph_requires graph vertex_list adjacency_list vertex_map
-    
-    if !is_directed(graph)
-        throw(ArgumentError("topological_sort_by_dfs: The input graph must be directed."))
-    end
+    @graph_requires graph vertex_list incidence_list vertex_map
 
     cmap = zeros(Int, num_vertices(graph))
     visitor = TopologicalSortVisitor{V}(num_vertices(graph))
 
     for s in vertices(graph)
         if cmap[s] == 0
-            traverse_graph(graph, DepthFirst(), s, visitor, colormap=cmap)
+            traverse_graph(graph, DepthFirst(), s, visitor, vertexcolormap=cmap)
         end
     end
 
     reverse(visitor.vertices)
 end
-
-
-
-
-
 

--- a/src/depth_first_visit.jl
+++ b/src/depth_first_visit.jl
@@ -58,18 +58,10 @@ function traverse_graph{V,G <: AbstractGraph}(
     alg::DepthFirst,
     s::V,
     visitor::AbstractGraphVisitor;
-    vertexcolormap = nothing,
-    edgecolormap = nothing)
+    vertexcolormap = zeros(Int, num_vertices(graph)),
+    edgecolormap = zeros(Int, num_edges(graph)))
 
     @graph_requires graph incidence_list vertex_map
-
-    if vertexcolormap == nothing
-        vertexcolormap = zeros(Int, num_vertices(graph))
-    end
-
-    if edgecolormap == nothing
-        edgecolormap = zeros(Int, num_edges(graph))
-    end
 
     vertexcolormap[vertex_index(s, graph)] = 1
     if !discover_vertex!(visitor, s)

--- a/src/graph_visit.jl
+++ b/src/graph_visit.jl
@@ -12,7 +12,7 @@ discover_vertex!(vis::AbstractGraphVisitor, v) = true
 open_vertex!(vis::AbstractGraphVisitor, v) = nothing
 
 # invoked when a neighbor is discovered & examined
-examine_neighbor!(vis::AbstractGraphVisitor, u, v, color::Int) = nothing
+examine_neighbor!(vis::AbstractGraphVisitor, u, v, color::Int, ecolor::Int) = nothing
 
 # invoked when an edge is discovered & examined
 examine_edge!(vis::AbstractGraphVisitor, e, color::Int) = nothing
@@ -39,11 +39,11 @@ abstract AbstractGraphVisitAlgorithm
 
 type VertexListVisitor{V} <: AbstractGraphVisitor
     vertices::Vector{V}
-    
+
     function VertexListVisitor(n::Integer)
         vs = Array(V, 0)
         sizehint(vs, n)
-        new(vs)        
+        new(vs)
     end
 end
 
@@ -53,17 +53,17 @@ function discover_vertex!{V}(visitor::VertexListVisitor{V}, v::V)
 end
 
 function visited_vertices{V,E}(
-    graph::AbstractGraph{V,E}, 
+    graph::AbstractGraph{V,E},
     alg::AbstractGraphVisitAlgorithm,
     sources)
-    
+
     visitor = VertexListVisitor{V}(num_vertices(graph))
     traverse_graph(graph, alg, sources, visitor)
     visitor.vertices::Vector{V}
 end
 
 
-# Print visit log 
+# Print visit log
 
 type LogGraphVisitor{S<:IO} <: AbstractGraphVisitor
     io::S
@@ -77,8 +77,8 @@ end
 open_vertex!(vis::LogGraphVisitor, v) = println(vis.io, "open vertex: $v")
 close_vertex!(vis::LogGraphVisitor, v) = println(vis.io, "close vertex: $v")
 
-function examine_neighbor!(vis::LogGraphVisitor, u, v, color::Int) 
-    println(vis.io, "examine neighbor: $u -> $v (color = $color)")
+function examine_neighbor!(vis::LogGraphVisitor, u, v, vcolor::Int, ecolor::Int)
+    println(vis.io, "examine neighbor: $u -> $v (vertexcolor = $vcolor, edgecolor= $ecolor)")
 end
 
 function examine_edge!(vis::LogGraphVisitor, e, color::Int)
@@ -90,6 +90,6 @@ function traverse_graph_withlog(g::AbstractGraph, alg::AbstractGraphVisitAlgorit
     traverse_graph(g, alg, sources, visitor)
 end
 
-traverse_graph_withlog(g::AbstractGraph, alg::AbstractGraphVisitAlgorithm, 
+traverse_graph_withlog(g::AbstractGraph, alg::AbstractGraphVisitAlgorithm,
     sources) = traverse_graph_withlog(g, alg, sources, STDOUT)
 


### PR DESCRIPTION
Previously test_cyclic_by_dfs only worked for directed tests. This commit adds
cycle tests for undirected graphs. This requires the addition of a colormap
for graph edges.
