### PR TITLE
fix weight_matrix, remove weight_matrix_sparse

### DIFF
--- a/doc/source/matrix.rst
+++ b/doc/source/matrix.rst
@@ -32,8 +32,9 @@ A *weight matrix* is defined as
 .. math::
 
     W(u, v) = \begin{cases}
-        w(e) & e = (u, v) \in E \\
-        0 & \text{otherwise}
+        0 & u = v \\
+        w(e) & u \ne v \text{ and } \{u, v\} \in E \\
+        Inf & \text{otherwise}
     \end{cases}
     
 .. py:function:: weight_matrix(is_directed, n, edges, eweights)

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -46,7 +46,7 @@ module Graphs
         
         # gmatrix
         adjacency_matrix, weight_matrix, laplacian_matrix,
-        adjacency_matrix_sparse, weight_matrix_sparse, laplacian_matrix_sparse,
+        adjacency_matrix_sparse, laplacian_matrix_sparse,
         sparse2adjacencylist,
         
         # graph_visit

--- a/test/gmatrix.jl
+++ b/test/gmatrix.jl
@@ -49,23 +49,14 @@ end
 
 eweights = [1., 2., 3., 4.]
 
-wm0  = [0. 1. 2. 0.; 0. 0. 0. 3.; 0. 0. 0. 4.; 0. 0. 0. 0.]
-wm0u = [0. 1. 2. 0.; 1. 0. 0. 3.; 2. 0. 0. 4.; 0. 3. 4. 0.]
+wm0  = [0. 1. 2. Inf; Inf 0. Inf 3.; Inf Inf 0. 4.; Inf Inf Inf 0.]
+wm0u = [0. 1. 2. Inf; 1. 0. Inf 3.; 2. Inf 0. 4.; Inf 3. 4. 0.]
 
 @test weight_matrix(true, 4, edges, eweights) == wm0
 @test weight_matrix(false, 4, edges, eweights) == wm0u
 
 @test weight_matrix(gd, eweights) == wm0
 @test weight_matrix(gu, eweights) == wm0u
-
-wm0_s = sparse(wm0)
-wm0u_s = sparse(wm0u)
-
-@test weight_matrix_sparse(true, 4, edges, eweights) == wm0_s
-@test weight_matrix_sparse(false, 4, edges, eweights) == wm0u_s
-
-@test weight_matrix_sparse(gd, eweights) == wm0_s
-@test weight_matrix_sparse(gu, eweights) == wm0u_s
 
 # Laplacian matrix
 


### PR DESCRIPTION
when (i,j) is not an edge of graph, weight w_{i,j} should be Inf instead of 0.
weight w_{i,j} should be 0 only when i==j

therefore, there would be no sparse version of weight matrix
