### PR TITLE
several remove and a fix for test

### DIFF
--- a/src/incidence_list.jl
+++ b/src/incidence_list.jl
@@ -95,6 +95,6 @@ inclist{V}(vty::Type{V}; is_directed::Bool = true) =
                                 inclist(V, Edge{V}, is_directed=is_directed)
 
 function inclist{V, E}(vty::Type{V}, ety::Type{E}; is_directed::Bool = true)
-    inclist = Array(Vector{E},0)
-    VectorIncidenceList{V, E}(is_directed, Array(V, 0), 0, inclist)
+    inc_list = Array(Vector{E},0)
+    VectorIncidenceList{V, E}(is_directed, Array(V, 0), 0, inc_list)
 end


### PR DESCRIPTION
`inclist` function has a variable called itself. The variable should be renamed.

remove unnecessary `vertex_index(V,G)`  `edge_index(E,G)` `source(V,G)` `target(V,G)` functions
remove unnecessary `VecProxy`
