### PR TITLE
Fix warning about missing :end

### DIFF
--- a/src/connected_components.jl
+++ b/src/connected_components.jl
@@ -127,7 +127,7 @@ end
 function close_vertex!(vis::TarjanVisitor, v)
     v_idx = vis.vertex_index(v)
     if vis.index[v_idx] == vis.lowlink[end]
-        component = vis.stack[vis.index[v_idx]:]
+        component = vis.stack[vis.index[v_idx]:end]
         splice!(vis.stack, vis.index[v_idx]:length(vis.stack))
         pop!(vis.lowlink)
         push!(vis.components, component)


### PR DESCRIPTION
Fixes:

```
WARNING: deprecated syntax "x[i:]" at .../.julia/Graphs/src/connected_components.jl:130.
Use "x[i:end]" instead.
```
