### PR TITLE
Rename inclist variable to be different from function name

### DIFF
--- a/src/incidence_list.jl
+++ b/src/incidence_list.jl
@@ -95,6 +95,6 @@ inclist{V}(vty::Type{V}; is_directed::Bool = true) =
                                 inclist(V, Edge{V}, is_directed=is_directed)
 
 function inclist{V, E}(vty::Type{V}, ety::Type{E}; is_directed::Bool = true)
-    inclist = Array(Vector{E},0)
-    VectorIncidenceList{V, E}(is_directed, Array(V, 0), 0, inclist)
+    _inclist = Array(Vector{E},0)
+    VectorIncidenceList{V, E}(is_directed, Array(V, 0), 0, _inclist)
 end


### PR DESCRIPTION
Variable names are not allowed to be the same as the function in Julia-HEAD anymore. This fixes the following error:

```
ERROR: invalid redefinition of constant inclist
 in inclist at /home/uwe/.julia/Graphs/src/incidence_list.jl:98
 in include at boot.jl:240
```
