### PR TITLE
Return created edge on add_edge!

### DIFF
--- a/src/incidence_list.jl
+++ b/src/incidence_list.jl
@@ -1,4 +1,3 @@
-
 ###########################################################
 #
 #   GenericIncidenceList{V, E, VList, IncList}
@@ -79,6 +78,7 @@ function add_edge!{V,E}(g::GenericIncidenceList{V, E}, u::V, v::V)
     if !g.is_directed
         push!(g.inclist[vi], revedge(e))
     end
+    e
 end
 
 # mutation


### PR DESCRIPTION
This is present for the GenericGraph version of add_edge! but was missing for the IncidenceList version of add_edge!.
