### PR TITLE
Enable release and nightlies tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ compiler:
     - gcc
 notifications:
     email: false
+env:
+    matrix: 
+        - JULIAVERSION="juliareleases" 
+        - JULIAVERSION="julianightlies" 
 before_install:
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-    - sudo add-apt-repository ppa:staticfloat/julianightlies -y
+    - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
     - sudo apt-get update -qq -y
     - sudo apt-get install libpcre3-dev julia -y
     - git config --global user.name "Travis User"


### PR DESCRIPTION
Tests pass successfully on Travis for both 0.2 and 0.3 versions
