### PR TITLE
fix error caused by wrong field call inside getindex of TargetIterator

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -117,7 +117,7 @@ TargetIterator{G<:AbstractGraph,EList}(g::G, lst::EList) =
 
 length(a::TargetIterator) = length(a.lst)
 isempty(a::TargetIterator) = isempty(a.lst)
-getindex(a::TargetIterator, i::Integer) = target(a.edges[i], a.g)
+getindex(a::TargetIterator, i::Integer) = target(a.lst[i], a.g)
 
 start(a::TargetIterator) = start(a.lst)
 done(a::TargetIterator, s) = done(a.lst, s)

--- a/test/inclist.jl
+++ b/test/inclist.jl
@@ -71,6 +71,12 @@ add_edge!(gd, 4, 5)
 
 @test collect_edges(gd) == [Edge(1,1,2), Edge(3,1,3), Edge(2,2,4), Edge(5,2,3), Edge(4,3,4), Edge(6,4,5)]
 
+target_it = out_neighbors(1, gd)
+@test !isempty(target_it)
+@test length(target_it) == 2
+@test target_it[1] == 2
+@test target_it[2] == 3
+
 
 #################################################
 #


### PR DESCRIPTION
Hi,

this is how I reproduce the error:

``` Julia
julia> sg = simple_inclist(4)
Directed Graph (4 vertices, 0 edges)

julia> add_edge!(sg, 1, 2)

julia> sit = out_neighbors(vertices(sg)[2], sg)
TargetIterator{GenericIncidenceList{Int64,Edge{Int64},Range1{Int64},Array{Array{Edge{Int64},1},1}},Array{Edge{Int64},1}}(Directed Graph (4 vertices, 0 edges),[])

julia> getindex(sit, 1)
ERROR: type TargetIterator has no field edges
 in getindex at /Users/luca/.julia/v0.2/Graphs/src/common.jl:120
```
