### PR TITLE
Make simple_graph editable

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -17,12 +17,12 @@ end
 # SimpleGraph:
 #   V:          Int
 #   E:          IEdge
-#   VList:      Range1{Int}
+#   VList:      Vector{Int}
 #   EList:      Vector{IEdge}
 #   AdjList:    Vector{Vector{Int}}
 #   IncList:    Vector{Vector{IEdge}}
 #
-typealias SimpleGraph GenericGraph{Int,IEdge,Range1{Int},Vector{IEdge},Vector{Vector{IEdge}}}
+typealias SimpleGraph GenericGraph{Int,IEdge,Vector{Int},Vector{IEdge},Vector{Vector{IEdge}}}
 
 typealias Graph{V,E} GenericGraph{V,E,Vector{V},Vector{E},Vector{Vector{E}}}
 
@@ -30,7 +30,7 @@ typealias Graph{V,E} GenericGraph{V,E,Vector{V},Vector{E},Vector{Vector{E}}}
 
 simple_graph(n::Integer; is_directed::Bool=true) = 
     SimpleGraph(is_directed,  
-                1:int(n),  # vertices
+                [1:int(n)],  # vertices
                 IEdge[],   # edges 
                 multivecs(IEdge, n), # finclist
                 multivecs(IEdge, n)) # binclist

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -75,6 +75,11 @@ es = [  add_edge!(sgd, 1, 2)
 @test collect(in_neighbors(3, sgd)) == [1]
 @test collect(in_neighbors(4, sgd)) == [2, 3]
 
+# adding edges
+
+@test add_vertex!(sgd, 5) == 5
+@test num_vertices(sgd) == 5
+
 
 #################################################
 #
@@ -133,6 +138,10 @@ rs = [revedge(e) for e in es]
 @test collect(in_neighbors(3, sgu)) == [1, 4]
 @test collect(in_neighbors(4, sgu)) == [2, 3, 1]
 
+# adding edges
+
+@test add_vertex!(sgu, 5) == 5
+@test num_vertices(sgu) == 5
 
 #################################################
 #


### PR DESCRIPTION
With this simple change we can add vertices to simple_graph instances. Range1 seems to be immutable or at least not extenable with `push!`
