### PR TITLE
Update cliques to initialize pivotdonenbrs

### DIFF
--- a/src/cliques.jl
+++ b/src/cliques.jl
@@ -30,6 +30,7 @@ function maximal_cliques{V}(g::AbstractGraph{V})
     maxconn = -1
     nnbrs = Dict()
     pivotnbrs = Set() # handle empty graph
+    pivotdonenbrs = Set()  # initialize
 
     for n in vertices(g)
         nbrs = Set()


### PR DESCRIPTION
pivotdonenbrs is not in a high enough scope to be seen between when it is defined and when it is referenced the second time.  Without this change I get:

```
ERROR: pivotdonenbrs not defined
 in maximal_cliques at /home/user/.julia/v0.3/Graphs/src/cliques.jl:125
while loading solver.jl, in expression starting on line 38
```
