### PR TITLE
Make DFS tests pass on 32-bit machines.

### DIFF
--- a/test/dfs.jl
+++ b/test/dfs.jl
@@ -4,7 +4,7 @@ using Graphs
 using Base.Test
 
 type GraphTest
-    graph_edges::Array{(Int64,Int64),1}
+    graph_edges::Array{(Int,Int),1}
     dfs_path::Array{Int,1}
     is_cyclic::Bool
     topo_sort::Array{Int,1}


### PR DESCRIPTION
simple_inclist uses Ints for vertices; on 32-bit machines, Int == Int32.
But test/dfs.jl hard-coded the use of Int64s for test data, which caused
type errors.
