### PR TITLE
Added the niche model of food web structure to random graphs

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.3-
 DataStructures 0.2.9-
+Distributions 0.2-

--- a/doc/source/algorithms.rst
+++ b/doc/source/algorithms.rst
@@ -276,3 +276,23 @@ including short average path lengths and high clustering.
 .. py:function:: watts_strogatz_graph(n, k, beta)
 
     Convenience function to construct an ``n``-vertex Watts-Strogatz graph as an incidence list.
+
+Niche model graphs
+~~~~~~~~~~~~~~~~~~
+
+The `Niche model <http://www.nature.com/nature/journal/v404/n6774/abs/404180a0.html>`_ is
+used to generate realistic random graphs resembling predator-prey networks, or food webs. Its inputs
+are a number of species, and expected connectance (density)
+
+.. py:function:: niche_model_graphs(g, S, C)
+
+   Generates one random model with ``S`` species
+
+   :param S: number of species (vertices)
+   :param C: expected connectance (density), between 0 (no arcs) and 1 (complete graph)
+
+   :returns: the directed graph ``g``
+
+.. py:function:: niche_model_graph(S, C)
+
+   Convenience function to generate a graph using the niche model

--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -1,5 +1,6 @@
 module Graphs
     using DataStructures
+    using Distributions
     
     import Base: start, done, next, show, ==
     import Base: length, isempty, size, getindex, isless
@@ -89,7 +90,7 @@ module Graphs
         to_dot, plot,
         
         # Random Graph Generation
-        erdos_renyi_graph, watts_strogatz_graph
+        erdos_renyi_graph, watts_strogatz_graph, niche_model_graph
         
     include("concepts.jl")
     include("common.jl")

--- a/src/random.jl
+++ b/src/random.jl
@@ -65,3 +65,47 @@ function watts_strogatz_graph(n::Integer, k::Integer, beta::Real)
     g = simple_inclist(n, is_directed=false)
     watts_strogatz_graph(g,n,k,beta)
 end
+
+# Generate a graph using Williams & Martinez "Niche" model of food web
+# See paper: http://www.nature.com/nature/journal/v404/n6774/abs/404180a0.html
+# The niche model generates realistic food webs / trophic networks
+# Each vertex is a species, with three traits
+#   n: a "niche" trait (equivalent to body size)
+#   c: the centroid of a species niche, i.e. the average size of its preys
+#   r: the range of a species, i.e. the breadth of preys it can eat
+# The arguments needed are
+#   S: the number of species
+#   C: the expected connectance (/density)
+
+function niche_model_graph{GT<:AbstractGraph}(g::GT, S::Integer, C::Real)
+   n = Array(Real, S)
+   r = Array(Real, S)
+   c = Array(Real, S)
+   # Loop 1 to get the species traits
+   for i in 1:S
+      n[i] = rand(Uniform())
+      r[i] = n[i] * rand(Beta(1, 1/(2*C)+1))
+      c[i] = rand(Uniform(r[i]/2, n[i]))
+   end
+   # Loop through all vertices to add arcs
+   for i in 1:S
+      for j in i:S
+         # i -> j ?
+         if ((n[j] < c[i]+r[i]) && (n[j] > c[i]-r[i]))
+            add_edge!(g, i, j)
+         end
+         # j -> i ?
+         if ((n[i] < c[j]+r[j]) && (n[i] > c[j]-r[j]))
+            add_edge!(g, j, i)
+         end
+      end
+   end
+   return g
+end
+
+# Convenience function with a default graph type
+function niche_model_graph(S::Integer, C::Real)
+   g = simple_inclist(S, is_directed=true)
+   niche_model_graph(g, S, C)
+end
+

--- a/src/random.jl
+++ b/src/random.jl
@@ -77,10 +77,10 @@ end
 #   S: the number of species
 #   C: the expected connectance (/density)
 
-function niche_model_graph{GT<:AbstractGraph}(g::GT, S::Integer, C::Real)
-   n = Array(Real, S)
-   r = Array(Real, S)
-   c = Array(Real, S)
+function niche_model_graph{T<:Real, GT<:AbstractGraph}(g::GT, S::Integer, C::T)
+   n = Array(T, S)
+   r = Array(T, S)
+   c = Array(T, S)
    # Loop 1 to get the species traits
    for i in 1:S
       n[i] = rand(Uniform())

--- a/test/random.jl
+++ b/test/random.jl
@@ -51,3 +51,12 @@ let g = watts_strogatz_graph(n, k, beta)
 	@test num_edges(g) == n*(k/2)
 	@test num_vertices(g) == n
 end
+
+
+# Niche model
+S = 10
+C = 0.2
+let g = niche_model_graph(S, C)
+   @test num_vertices(g) == S
+end
+


### PR DESCRIPTION
The _niche model_ is widely used by food web ecologists to generate random (directed) graphs resembling empirical predator-prey networks. I've used the same template as the other two random graphs already implemented, and updated the tests and doc as well.
