### PR TITLE
Test against Julia releases in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ notifications:
     email: false
 env:
     matrix: 
-        # - JULIAVERSION="juliareleases" 
+        - JULIAVERSION="juliareleases"
         - JULIAVERSION="julianightlies" 
 before_install:
     - sudo add-apt-repository ppa:staticfloat/julia-deps -y


### PR DESCRIPTION
This reverts ea4f4d0; only testing against nightlies made it harder to track down a couple of build failures that were due to changes in the Julia compiler.

Submitting as a pull request both to enable discussion (I'm sure ea4f4d0 was made for good reasons, but I can't think what they were), and to find out what happens to the Travis build.
