### PR TITLE
fix topological sort for undirected graphs

### DIFF
--- a/doc/source/algorithms.rst
+++ b/doc/source/algorithms.rst
@@ -96,7 +96,7 @@ Topological sorting of an acyclic directed graph is a linear ordering of vertice
 
 .. py:function:: topological_sort_by_dfs(g)
 
-    Returns a topological sorting of the vertices in ``g`` in the form of a vector of vertices. Here, ``g`` must be a directed graph, and implement ``vertex_list``, ``vertex_map``, and ``adjacency_list``.
+    Returns a topological sorting of the vertices in ``g`` in the form of a vector of vertices. Here, ``g`` may be directed or undirected, and implement ``vertex_list``, ``vertex_map``, and ``adjacency_list``.
     
     
 Shortest Paths

--- a/src/depth_first_visit.jl
+++ b/src/depth_first_visit.jl
@@ -136,7 +136,7 @@ end
 
 
 function examine_neighbor!{V}(visitor::TopologicalSortVisitor{V}, u::V, v::V, vcolor::Int, ecolor::Int)
-    if vcolor == 1
+    if vcolor == 1 && ecolor == 0
         throw(ArgumentError("The input graph contains at least one loop."))
     end
 end

--- a/test/dfs.jl
+++ b/test/dfs.jl
@@ -17,12 +17,12 @@ dir_acyclic = GraphTest(
     [(1,2), (1,3), (1,6), (2,4), (2,5), (3,5), (3,6)],
     [1, 2, 4, 5, 3, 6],
     false,
-    [])
+    [1,3,6,2,5,4])
 undir_acyclic = GraphTest(
     [(1,2), (1,3), (1,6), (2,4), (2,5)],
     [],
     false,
-    [])
+    [1,6,3,2,5,4])
 cyclic  = GraphTest(
     [(1,2), (1,3), (1,6), (2,4), (2,5), (3,5), (3,6), (5,1)],
     [1, 2, 4, 5, 3, 6],
@@ -70,7 +70,7 @@ for tset in testsets
             @assert ts == gtest.topo_sort
 
             ts = topological_sort_by_dfs(gEx)
-            @assert ts == gtest.topo_sort
+            @assert [vertex_index(e,gEx) for e in ts] == gtest.topo_sort
         end
     end
 end


### PR DESCRIPTION
`topological_sort_by_dfs` wasn't actually being fully tested. Tests will fail with DataStructures master because of JuliaLang/DataStructures.jl#29
