### PR TITLE
Remember to return the state from dijkstra's algorithm when terminating ...

### DIFF
--- a/src/dijkstra_spath.jl
+++ b/src/dijkstra_spath.jl
@@ -166,7 +166,7 @@ function dijkstra_shortest_paths!{V, D, Heap, H}(
     for s in sources
         set_source!(state, graph, s)        
         if !include_vertex!(visitor, s, s, d0)
-            return
+            return state
         end
     end
     
@@ -189,7 +189,7 @@ function dijkstra_shortest_paths!{V, D, Heap, H}(
         ui = vertex_index(u, graph)
         colormap[ui] = 2
         if !include_vertex!(visitor, parents[ui], u, du)
-            return
+            return state
         end
         
         # process u's neighbors

--- a/test/dijkstra.jl
+++ b/test/dijkstra.jl
@@ -41,6 +41,22 @@ s1 = dijkstra_shortest_paths(g1, eweights1, [1])
 @test s1.dists == [0., 8., 5., 9., 7.]
 @test s1.colormap == [2, 2, 2, 2, 2]
 
+# Check early termination
+
+type EndWhenNode <: AbstractDijkstraVisitor
+  n::Int
+end
+
+function Graphs.include_vertex!(visitor::EndWhenNode, u, v, d)
+  v != visitor.n
+end
+
+s1b = dijkstra_shortest_paths(g1, eweights1, [1], visitor=EndWhenNode(5))
+
+@test s1b.parents == [1, 3, 1, 3, 3]
+@test s1b.dists == [0.0, 8.0, 5.0, 14.0, 7.0]
+@test s1b.colormap == [2, 1, 2, 1, 2] 
+
 # g2: the example in Wikipedia
 g2 = simple_inclist(6, is_directed=false)
 


### PR DESCRIPTION
...early

(upon finding the shortest path to the node we are interested in).
github issue #76

When exiting Dijkstra's algorithm early by returning false from include_vertex! we return nothing, thereby contributing to the heat death of the universe and not much else.  Returning 'state' allows us to retrieve the shortest paths found so far.  This, I believe, is what @ehelle was getting at in issue #76.
