### PR TITLE
Dijkstra's algorithm as currently formulated requires vertex_map and edg...

### DIFF
--- a/doc/source/algorithms.rst
+++ b/doc/source/algorithms.rst
@@ -121,7 +121,8 @@ Dijkstra's Algorithm
     
     :returns:           An instance of ``DijkstraStates`` that encapsulates the results.
     
-Here, ``graph`` can be directed or undirected. It must implement ``vertex_map`` and ``incidence_list``. The following is an example that shows how to use this function:
+Here, ``graph`` can be directed or undirected. It must implement
+``vertex_map``, ``edge_map`` and ``incidence_list``. The following is an example that shows how to use this function:
 
 .. code-block:: python
 

--- a/src/dijkstra_spath.jl
+++ b/src/dijkstra_spath.jl
@@ -149,7 +149,7 @@ function dijkstra_shortest_paths!{V, D, Heap, H}(
     visitor::AbstractDijkstraVisitor,       # visitor object
     state::DijkstraStates{V,D,Heap,H})      # the states   
     
-    @graph_requires graph incidence_list                
+    @graph_requires graph incidence_list vertex_map edge_map
 
     # get state fields
     


### PR DESCRIPTION
...e_map

in addition to incidence_list.  This adds the appropriate check, as well as fixing the documentation.

This is probably too trivial to deal with, but the code does require `vertex_map` for indexing into the color table and `edge_map` for indexing into the distance table.  The call to `vertex_index` is probably not worth avoiding, but it seems to me that it might be worth moving the weight table into a function that is passed in.  I often need to compute shortest paths on graphs where all the edges have the same length, and so do not need a table, and in the cases where I don't the edge length is stored in a structure (type) that is easily accessible, and I doubt the cost of extracting the length into a separate array is substantially less than calling it as we need it. 

However, it makes no sense to just add an edge weight function just to Dijkstra's algorithm, and I figured that I'd let wiser heads tell me off before I went off and made a mess of things.  
