### PR TITLE
Fix shortcut

### DIFF
--- a/src/cliques.jl
+++ b/src/cliques.jl
@@ -82,7 +82,7 @@ function maximal_cliques{V}(g::AbstractGraph{V})
             continue
         end
         # Shortcut--only one node left!
-        if !isempty(new_done) && length(new_cand) == 1
+        if isempty(new_done) && length(new_cand) == 1
             push!(cliques, cat(1, clique_so_far, collect(new_cand)))
             pop!(clique_so_far)
             continue

--- a/src/cliques.jl
+++ b/src/cliques.jl
@@ -28,12 +28,12 @@ function maximal_cliques{V}(g::AbstractGraph{V})
 
     # Cache nbrs and find first pivot (highest degree)
     maxconn = -1
-    nnbrs = Dict()
-    pivotnbrs = Set() # handle empty graph
-    pivotdonenbrs = Set()  # initialize
+    nnbrs = Dict{V,Set{V}}()
+    pivotnbrs = Set{V}() # handle empty graph
+    pivotdonenbrs = Set{V}()  # initialize
 
     for n in vertices(g)
-        nbrs = Set()
+        nbrs = Set{V}()
         union!(nbrs, out_neighbors(n, g))
         delete!(nbrs, n) # ignore edges between n and itself
         conn = length(nbrs)
@@ -47,11 +47,11 @@ function maximal_cliques{V}(g::AbstractGraph{V})
     end
 
     # Initial setup
-    cand = Set()
+    cand = Set{V}()
     union!(cand, keys(nnbrs))
     smallcand = setdiff(cand, pivotnbrs)
-    done = Set()
-    stack = (Set, Set, Set)[]
+    done = Set{V}()
+    stack = (Set{V}, Set{V}, Set{V})[]
     clique_so_far = V[]
     cliques = Array{V}[]
 

--- a/test/cliques.jl
+++ b/test/cliques.jl
@@ -28,3 +28,15 @@ add_edge!(h, 3, 6)
 add_edge!(h, 5, 6)
 
 @test maximal_cliques(h) != []
+
+# test for extra cliques bug
+
+g2 = simple_inclist(7, is_directed=false)
+add_edge!(g2,1,3)
+add_edge!(g2,2,6)
+add_edge!(g2,3,5)
+add_edge!(g2,3,6)
+add_edge!(g2,4,5)
+add_edge!(g2,4,7)
+add_edge!(g2,5,7)
+@test test_cliques(g2, Array[[7,4,5], [2,6], [3,5], [3,6], [3,1]])


### PR DESCRIPTION
This fixes the bug reported in #96 there was a typo in translation from python.  The current code was tested on 100 100 vertex Erdos Renyi graphs (p=0.1) against an implementation of the naive Bron Kerbosch algorithm.   

It also adds types to the sets as discussed in #95.  This should probably be a separate PR, but the two fixes are sufficiently trivial, so this shouldn't be a problem.  This along with the recent fixes to Set should speed things considerably.
