### PR TITLE
correctly count the number of graph types

### DIFF
--- a/doc/source/graphs.rst
+++ b/doc/source/graphs.rst
@@ -2,7 +2,7 @@ Graph Types
 ===========
 
 This package provides several graph types that implement different subsets of interfaces.
-In particular, it has three graph types:
+In particular, it has four graph types:
 
 * ``GenericEdgeList``
 * ``GenericAdjacencyList``


### PR DESCRIPTION
The documentation claims there are three graph types immediately before listing four. 
