### PR TITLE
Preserving symmetry of edges for undirected graphs

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -90,6 +90,7 @@ function add_edge!{V,E}(g::GenericGraph{V,E}, u::V, v::V, e::E)
 
     if !g.is_directed
         rev_e = revedge(e)
+        push!(g.edges, rev_e)
         push!(g.finclist[vi], rev_e)
         push!(g.binclist[ui], rev_e)
     end


### PR DESCRIPTION
If `e in edges(g) == true`, it follows that `revedge(e) in edges(g) == true` for undirected graphs.
