### PR TITLE
RFC: Allow general vertex types (fixes #105)

### DIFF
--- a/src/adjacency_list.jl
+++ b/src/adjacency_list.jl
@@ -35,18 +35,18 @@ is_directed(g::GenericAdjacencyList) = g.is_directed
 
 num_vertices(g::GenericAdjacencyList) = length(g.vertices)
 vertices(g::GenericAdjacencyList) = g.vertices
-vertex_index{V}(v::V, g::GenericAdjacencyList{V}) = vertex_index(v)
+vertex_index{V<:ProvidedVertexType}(v::V, g::GenericAdjacencyList{V}) = vertex_index(v)
 
 num_edges(g::GenericAdjacencyList) = g.nedges
 
-out_degree{V}(v::V, g::GenericAdjacencyList{V}) = length(g.adjlist[vertex_index(v)])
-out_neighbors{V}(v::V, g::GenericAdjacencyList{V}) = g.adjlist[vertex_index(v)]
+out_degree{V}(v::V, g::GenericAdjacencyList{V}) = length(g.adjlist[vertex_index(v,g)])
+out_neighbors{V}(v::V, g::GenericAdjacencyList{V}) = g.adjlist[vertex_index(v,g)]
 
 
 ## mutation
 
 function add_vertex!{V}(g::GenericAdjacencyList{V}, v::V)
-    @assert vertex_index(v) == num_vertices(g) + 1
+    @assert !isa(V, ProvidedVertexType) || vertex_index(v) == num_vertices(g) + 1
     push!(g.vertices, v)
     push!(g.adjlist, Array(V,0))
     v

--- a/src/adjacency_list.jl
+++ b/src/adjacency_list.jl
@@ -46,7 +46,6 @@ out_neighbors{V}(v::V, g::GenericAdjacencyList{V}) = g.adjlist[vertex_index(v,g)
 ## mutation
 
 function add_vertex!{V}(g::GenericAdjacencyList{V}, v::V)
-    @assert !isa(V, ProvidedVertexType) || vertex_index(v) == num_vertices(g) + 1
     push!(g.vertices, v)
     push!(g.adjlist, Array(V,0))
     v

--- a/src/common.jl
+++ b/src/common.jl
@@ -31,6 +31,17 @@ make_vertex(g::AbstractGraph{ExVertex}, label::String) = ExVertex(num_vertices(g
 vertex_index(v::ExVertex) = v.index
 attributes(v::ExVertex, g::AbstractGraph) = v.attributes
 
+typealias ProvidedVertexType Union(Integer, KeyVertex, ExVertex)
+
+# vertex_index for (V !<: ProvidedVertexType)
+
+function vertex_index{V}(v::V, g::AbstractGraph{V})
+    @graph_requires g vertex_list
+    return vertex_index(v, vertices(g))
+end
+
+vertex_index(v, vs::AbstractArray) = findfirst(vs, v)
+
 
 #################################################
 #

--- a/src/dot.jl
+++ b/src/dot.jl
@@ -25,24 +25,24 @@ function to_dot{G<:AbstractGraph}(graph::G, stream::IO)
     write(stream, "$(graph_type_string(graph)) graphname {\n")
     if implements_edge_list(graph)
         for edge in edges(graph)
-            write(stream,"$(vertex_index(source(edge))) $(edge_op(graph)) $(vertex_index(target(edge)))\n")
+            write(stream,"$(vertex_index(source(edge), graph)) $(edge_op(graph)) $(vertex_index(target(edge), graph))\n")
         end
     elseif implements_vertex_list(graph) && (implements_incidence_list(graph) || implements_adjacency_list(graph))
         for vertex in vertices(graph)
             if has_vertex_attrs && !isempty(attributes(vertex, graph))
-                write(stream, "$(vertex_index(vertex)) $(to_dot(attributes(vertex, graph)))\n")
+                write(stream, "$(vertex_index(vertex, graph)) $(to_dot(attributes(vertex, graph)))\n")
             end
             if implements_incidence_list(graph)
                 for e in out_edges(vertex, graph)
                     n = target(e, graph)
-                    if is_directed(graph) || vertex_index(n) > vertex_index(vertex)
-                        write(stream,"$(vertex_index(vertex)) $(edge_op(graph)) $(vertex_index(n))$(has_edge_attrs ? string(" ", to_dot(attributes(e, graph))) : "")\n")
+                    if is_directed(graph) || vertex_index(n, graph) > vertex_index(vertex, graph)
+                        write(stream,"$(vertex_index(vertex, graph)) $(edge_op(graph)) $(vertex_index(n, graph))$(has_edge_attrs ? string(" ", to_dot(attributes(e, graph))) : "")\n")
                     end
                 end
             else # implements_adjacency_list
                 for n in out_neighbors(vertex, graph)
-                    if is_directed(graph) || vertex_index(n) > vertex_index(vertex)
-                        write(stream,"$(vertex_index(vertex)) $(edge_op(graph)) $(vertex_index(n))\n")
+                    if is_directed(graph) || vertex_index(n, graph) > vertex_index(vertex, graph)
+                        write(stream,"$(vertex_index(vertex, graph)) $(edge_op(graph)) $(vertex_index(n))\n")
                     end
                 end
             end

--- a/src/edge_list.jl
+++ b/src/edge_list.jl
@@ -26,7 +26,7 @@ is_directed(g::GenericEdgeList) = g.is_directed
 
 num_vertices(g::GenericEdgeList) = length(g.vertices)
 vertices(g::GenericEdgeList) = g.vertices
-vertex_index(v, g::GenericEdgeList) = vertex_index(v)
+vertex_index(v::ProvidedVertexType, g::GenericEdgeList) = vertex_index(v)
 
 num_edges(g::GenericEdgeList) = length(g.edges)
 edges(g::GenericEdgeList) = g.edges

--- a/src/edge_list.jl
+++ b/src/edge_list.jl
@@ -26,7 +26,7 @@ is_directed(g::GenericEdgeList) = g.is_directed
 
 num_vertices(g::GenericEdgeList) = length(g.vertices)
 vertices(g::GenericEdgeList) = g.vertices
-vertex_index(v::ProvidedVertexType, g::GenericEdgeList) = vertex_index(v)
+vertex_index{V<:ProvidedVertexType}(v::V, g::GenericEdgeList{V}) = vertex_index(v)
 
 num_edges(g::GenericEdgeList) = length(g.edges)
 edges(g::GenericEdgeList) = g.edges

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -70,7 +70,6 @@ in_neighbors{V}(v::V, g::GenericGraph{V}) = SourceIterator(g, in_edges(v, g))
 # mutation
 
 function add_vertex!{V}(g::GenericGraph{V}, v::V)
-    @assert !isa(V, ProvidedVertexType) || vertex_index(v, g) == num_vertices(g) + 1
     push!(g.vertices, v)
     push!(g.finclist, Int[])
     push!(g.binclist, Int[])
@@ -80,7 +79,6 @@ add_vertex!{V}(g::GenericGraph{V}, x) = add_vertex!(g, make_vertex(g, x))
 
 function add_edge!{V,E}(g::GenericGraph{V,E}, u::V, v::V, e::E)
     # add an edge e between u and v
-    @assert edge_index(e) == num_edges(g) + 1
     ui = vertex_index(u, g)::Int
     vi = vertex_index(v, g)::Int
 

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -55,14 +55,14 @@ vertices(g::GenericGraph) = g.vertices
 num_edges(g::GenericGraph) = length(g.edges)
 edges(g::GenericGraph) = g.edges
 
-vertex_index{V}(v::V, g::GenericGraph{V}) = vertex_index(v)
+vertex_index{V<:ProvidedVertexType}(v::V, g::GenericGraph{V}) = vertex_index(v)
 edge_index{V,E}(e::E, g::GenericGraph{V,E}) = edge_index(e)
 
-out_edges{V}(v::V, g::GenericGraph{V}) = g.finclist[vertex_index(v)]
+out_edges{V}(v::V, g::GenericGraph{V}) = g.finclist[vertex_index(v, g)]
 out_degree{V}(v::V, g::GenericGraph{V}) = length(out_edges(v, g))
 out_neighbors{V}(v::V, g::GenericGraph{V}) = TargetIterator(g, out_edges(v, g))
 
-in_edges{V}(v::V, g::GenericGraph{V}) = g.binclist[vertex_index(v)]
+in_edges{V}(v::V, g::GenericGraph{V}) = g.binclist[vertex_index(v, g)]
 in_degree{V}(v::V, g::GenericGraph{V}) = length(in_edges(v, g))
 in_neighbors{V}(v::V, g::GenericGraph{V}) = SourceIterator(g, in_edges(v, g))
 
@@ -70,7 +70,7 @@ in_neighbors{V}(v::V, g::GenericGraph{V}) = SourceIterator(g, in_edges(v, g))
 # mutation
 
 function add_vertex!{V}(g::GenericGraph{V}, v::V)
-    @assert vertex_index(v) == num_vertices(g) + 1
+    @assert !isa(V, ProvidedVertexType) || vertex_index(v, g) == num_vertices(g) + 1
     push!(g.vertices, v)
     push!(g.finclist, Int[])
     push!(g.binclist, Int[])

--- a/src/incidence_list.jl
+++ b/src/incidence_list.jl
@@ -52,7 +52,6 @@ out_neighbors{V}(v::V, g::GenericIncidenceList{V}) = TargetIterator(g, g.inclist
 # mutation
 
 function add_vertex!{V,E}(g::GenericIncidenceList{V,E}, v::V)
-    @assert !isa(V, ProvidedVertexType) || vertex_index(v,g) == num_vertices(g) + 1
     push!(g.vertices, v)
     push!(g.inclist, Array(E,0))
     v

--- a/src/incidence_list.jl
+++ b/src/incidence_list.jl
@@ -42,20 +42,17 @@ vertices(g::GenericIncidenceList) = g.vertices
 
 num_edges(g::GenericIncidenceList) = g.nedges
 
-vertex_index{V}(v::V, g::GenericIncidenceList{V}) = vertex_index(v)
+vertex_index{V<:ProvidedVertexType}(v::V, g::GenericIncidenceList{V}) = vertex_index(v)
 edge_index{V,E}(e::E, g::GenericIncidenceList{V,E}) = edge_index(e)
 
-out_edges{V}(v::V, g::GenericIncidenceList{V}) = g.inclist[vertex_index(v)]
+out_edges{V}(v::V, g::GenericIncidenceList{V}) = g.inclist[vertex_index(v, g)]
 out_degree{V}(v::V, g::GenericIncidenceList{V}) = length(out_edges(v, g))
-out_neighbors{V}(v::V, g::GenericIncidenceList{V}) = TargetIterator(g, g.inclist[vertex_index(v)])
+out_neighbors{V}(v::V, g::GenericIncidenceList{V}) = TargetIterator(g, g.inclist[vertex_index(v, g)])
 
 # mutation
 
 function add_vertex!{V,E}(g::GenericIncidenceList{V,E}, v::V)
-    iv::Int = vertex_index(v)
-    if iv != num_vertices(g) + 1
-        throw(ArgumentError("Invalid vertex index."))
-    end        
+    @assert !isa(V, ProvidedVertexType) || vertex_index(v,g) == num_vertices(g) + 1
     push!(g.vertices, v)
     push!(g.inclist, Array(E,0))
     v

--- a/test/adjlist.jl
+++ b/test/adjlist.jl
@@ -68,34 +68,36 @@ end
 
 # adjacency list with key vertices
 
-g = adjlist(KeyVertex{ASCIIString})
+for g in [adjlist(KeyVertex{ASCIIString}), adjlist(ASCIIString)]
 
-vs = [  add_vertex!(g, "a"), 
-        add_vertex!(g, "b"), 
-        add_vertex!(g, "c") ]
+    vs = [  add_vertex!(g, "a"), 
+            add_vertex!(g, "b"), 
+            add_vertex!(g, "c") ]
+    
+    @test num_vertices(g) == 3
 
-@test num_vertices(g) == 3
+    for i = 1 : 3
+        v = vs[i]
+        @test vertices(g)[i] == v
+        @test !isa(v, KeyVertex) || v.index == i
+        @test out_degree(v, g) == 0
+    end
 
-for i = 1 : 3
-    v = vs[i]
-    @test vertices(g)[i] == v
-    @test v.index == i
-    @test out_degree(v, g) == 0
+    add_edge!(g, vs[1], vs[2])
+    add_edge!(g, vs[1], vs[3])
+    add_edge!(g, vs[2], vs[3])
+
+    @test num_edges(g) == 3
+
+    @test out_degree(vs[1], g) == 2
+    @test out_degree(vs[2], g) == 1
+    @test out_degree(vs[3], g) == 0
+
+    @test out_neighbors(vs[1], g) == [vs[2], vs[3]]
+    @test out_neighbors(vs[2], g) == [vs[3]]
+    @test isempty(out_neighbors(vs[3], g))
+
 end
-
-add_edge!(g, vs[1], vs[2])
-add_edge!(g, vs[1], vs[3])
-add_edge!(g, vs[2], vs[3])
-
-@test num_edges(g) == 3
-
-@test out_degree(vs[1], g) == 2
-@test out_degree(vs[2], g) == 1
-@test out_degree(vs[3], g) == 0
-
-@test out_neighbors(vs[1], g) == [vs[2], vs[3]]
-@test out_neighbors(vs[2], g) == [vs[3]]
-@test isempty(out_neighbors(vs[3], g))
 
 # # construct via adjacency matrix
 # A = [true true true; false false true; false false true]

--- a/test/edgelist.jl
+++ b/test/edgelist.jl
@@ -49,22 +49,24 @@ gu = simple_edgelist(5, eds; is_directed=false)
 
 ## edge list (based on vector of vertices)
 
-g = edgelist(ExVertex[], ExEdge{ExVertex}[])
+for T in [ ExVertex, ASCIIString ]
+    g = edgelist(T[], ExEdge{T}[])
 
-vs = [ add_vertex!(g, "a"), 
-       add_vertex!(g, "b"), 
-       add_vertex!(g, "c") ]
+    vs = [ add_vertex!(g, "a"), 
+           add_vertex!(g, "b"), 
+           add_vertex!(g, "c") ]
 
-es = [ add_edge!(g, vs[1], vs[2]), 
-       add_edge!(g, vs[1], vs[3]) ]
+    es = [ add_edge!(g, vs[1], vs[2]), 
+           add_edge!(g, vs[1], vs[3]) ]
 
-@test vertex_type(g) == ExVertex
-@test edge_type(g) == ExEdge{ExVertex}
-@test is_directed(g)
+    @test vertex_type(g) == T
+    @test edge_type(g) == ExEdge{T}
+    @test is_directed(g)
 
-@test num_vertices(g) == 3
-@test vertices(g) == vs
+    @test num_vertices(g) == 3
+    @test vertices(g) == vs
 
-@test num_edges(g) == 2
-@test edges(g) == es
+    @test num_edges(g) == 2
+    @test edges(g) == es
+end
 

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -137,120 +137,123 @@ rs = [revedge(e) for e in es]
 @test collect(in_neighbors(4, sgu)) == [2, 3, 1]
 
 
+for T in [ExVertex, ASCIIString]
+
 #################################################
 #
-#  Extended directed graph
+#  Extended and General directed graph
 #
 #################################################
 
-egd = graph(ExVertex[], ExEdge{ExVertex}[])
-@test is_directed(egd) == true
+    egd = graph(T[], ExEdge{T}[])
+    @test is_directed(egd) == true
 
-names = ["a", "b", "c", "d"]
+    names = ["a", "b", "c", "d"]
 
-for (i, x) in enumerate(names)
-    v = add_vertex!(egd, x)
-    @test vertex_index(v, egd) == i
+    for (i, x) in enumerate(names)
+        v = add_vertex!(egd, x)
+        @test vertex_index(v, egd) == i
+    end
+    vs = vertices(egd)
+
+    @test num_vertices(egd) == 4
+    @test num_edges(egd) == 0
+
+    add_edge!(egd, vs[1], vs[2])
+    add_edge!(egd, vs[1], vs[3])
+    add_edge!(egd, vs[2], vs[4])
+    add_edge!(egd, vs[3], vs[4])
+    es = edges(egd)
+
+    @test num_edges(egd) == 4
+
+    # outgoing
+
+    @test [out_degree(v, egd) for v in vs] == [2, 1, 1, 0]
+
+    @test out_edges(vs[1], egd) == es[1:2]
+    @test out_edges(vs[2], egd) == [es[3]]
+    @test out_edges(vs[3], egd) == [es[4]]
+    @test isempty(out_edges(vs[4], egd))
+
+    @test collect(out_neighbors(vs[1], egd)) == [vs[2], vs[3]]
+    @test collect(out_neighbors(vs[2], egd)) == [vs[4]]
+    @test collect(out_neighbors(vs[3], egd)) == [vs[4]]
+    @test isempty(out_neighbors(vs[4], egd))
+
+    # incoming
+
+    @test [in_degree(v, egd) for v in vs] == [0, 1, 1, 2]
+
+    @test isempty(in_edges(vs[1], egd))
+    @test in_edges(vs[2], egd) == [es[1]]
+    @test in_edges(vs[3], egd) == [es[2]]
+    @test in_edges(vs[4], egd) == es[3:4]
+
+    @test isempty(in_neighbors(vs[1], egd))
+    @test collect(in_neighbors(vs[2], egd)) == [vs[1]]
+    @test collect(in_neighbors(vs[3], egd)) == [vs[1]]
+    @test collect(in_neighbors(vs[4], egd)) == vs[2:3]
+
+
+#################################################
+#
+#  Extended and General undirected graph
+#
+#################################################
+
+    egu = graph(T[], ExEdge{T}[]; is_directed=false)
+    @test is_directed(egu) == false
+
+    names = ["a", "b", "c", "d"]
+
+    for (i, x) in enumerate(names)
+        v = add_vertex!(egu, x)
+        @test vertex_index(v, egu) == i
+    end
+    vs = vertices(egu)
+
+    @test num_vertices(egu) == 4
+    @test num_edges(egu) == 0
+
+    add_edge!(egu, vs[1], vs[2])
+    add_edge!(egu, vs[1], vs[3])
+    add_edge!(egu, vs[2], vs[4])
+    add_edge!(egu, vs[3], vs[4])
+    es = edges(egu)
+    rs = [revedge(e) for e in es]
+
+    @test num_edges(egu) == 4
+
+    # outgoing
+
+    @test [out_degree(v, egu) for v in vs] == [2, 2, 2, 2]
+
+    @test out_edges(vs[1], egu) == [es[1], es[2]]
+    @test out_edges(vs[2], egu) == [rs[1], es[3]]
+    @test out_edges(vs[3], egu) == [rs[2], es[4]]
+    @test out_edges(vs[4], egu) == [rs[3], rs[4]]
+
+    @test collect(out_neighbors(vs[1], egu)) == [vs[2], vs[3]]
+    @test collect(out_neighbors(vs[2], egu)) == [vs[1], vs[4]]
+    @test collect(out_neighbors(vs[3], egu)) == [vs[1], vs[4]]
+    @test collect(out_neighbors(vs[4], egu)) == [vs[2], vs[3]]
+
+    # incoming
+
+    @test [in_degree(v, egu) for v in vs] == [2, 2, 2, 2]
+
+    @test in_edges(vs[1], egu) == [rs[1], rs[2]]
+    @test in_edges(vs[2], egu) == [es[1], rs[3]]
+    @test in_edges(vs[3], egu) == [es[2], rs[4]]
+    @test in_edges(vs[4], egu) == [es[3], es[4]]
+
+    @test collect(in_neighbors(vs[1], egu)) == [vs[2], vs[3]]
+    @test collect(in_neighbors(vs[2], egu)) == [vs[1], vs[4]]
+    @test collect(in_neighbors(vs[3], egu)) == [vs[1], vs[4]]
+    @test collect(in_neighbors(vs[4], egu)) == [vs[2], vs[3]]
+
 end
-vs = vertices(egd)
-
-@test num_vertices(egd) == 4
-@test num_edges(egd) == 0
-
-add_edge!(egd, vs[1], vs[2])
-add_edge!(egd, vs[1], vs[3])
-add_edge!(egd, vs[2], vs[4])
-add_edge!(egd, vs[3], vs[4])
-es = edges(egd)
-
-@test num_edges(egd) == 4
-
-# outgoing
-
-@test [out_degree(v, egd) for v in vs] == [2, 1, 1, 0]
-
-@test out_edges(vs[1], egd) == es[1:2]
-@test out_edges(vs[2], egd) == [es[3]]
-@test out_edges(vs[3], egd) == [es[4]]
-@test isempty(out_edges(vs[4], egd))
-
-@test collect(out_neighbors(vs[1], egd)) == [vs[2], vs[3]]
-@test collect(out_neighbors(vs[2], egd)) == [vs[4]]
-@test collect(out_neighbors(vs[3], egd)) == [vs[4]]
-@test isempty(out_neighbors(vs[4], egd))
-
-# incoming
-
-@test [in_degree(v, egd) for v in vs] == [0, 1, 1, 2]
-
-@test isempty(in_edges(vs[1], egd))
-@test in_edges(vs[2], egd) == [es[1]]
-@test in_edges(vs[3], egd) == [es[2]]
-@test in_edges(vs[4], egd) == es[3:4]
-
-@test isempty(in_neighbors(vs[1], egd))
-@test collect(in_neighbors(vs[2], egd)) == [vs[1]]
-@test collect(in_neighbors(vs[3], egd)) == [vs[1]]
-@test collect(in_neighbors(vs[4], egd)) == vs[2:3]
-
-
-#################################################
-#
-#  Extended undirected graph
-#
-#################################################
-
-egu = graph(ExVertex[], ExEdge{ExVertex}[]; is_directed=false)
-@test is_directed(egu) == false
-
-names = ["a", "b", "c", "d"]
-
-for (i, x) in enumerate(names)
-    v = add_vertex!(egu, x)
-    @test vertex_index(v, egu) == i
-end
-vs = vertices(egu)
-
-@test num_vertices(egu) == 4
-@test num_edges(egu) == 0
-
-add_edge!(egu, vs[1], vs[2])
-add_edge!(egu, vs[1], vs[3])
-add_edge!(egu, vs[2], vs[4])
-add_edge!(egu, vs[3], vs[4])
-es = edges(egu)
-rs = [revedge(e) for e in es]
-
-@test num_edges(egu) == 4
-
-# outgoing
-
-@test [out_degree(v, egu) for v in vs] == [2, 2, 2, 2]
-
-@test out_edges(vs[1], egu) == [es[1], es[2]]
-@test out_edges(vs[2], egu) == [rs[1], es[3]]
-@test out_edges(vs[3], egu) == [rs[2], es[4]]
-@test out_edges(vs[4], egu) == [rs[3], rs[4]]
-
-@test collect(out_neighbors(vs[1], egu)) == [vs[2], vs[3]]
-@test collect(out_neighbors(vs[2], egu)) == [vs[1], vs[4]]
-@test collect(out_neighbors(vs[3], egu)) == [vs[1], vs[4]]
-@test collect(out_neighbors(vs[4], egu)) == [vs[2], vs[3]]
-
-# incoming
-
-@test [in_degree(v, egu) for v in vs] == [2, 2, 2, 2]
-
-@test in_edges(vs[1], egu) == [rs[1], rs[2]]
-@test in_edges(vs[2], egu) == [es[1], rs[3]]
-@test in_edges(vs[3], egu) == [es[2], rs[4]]
-@test in_edges(vs[4], egu) == [es[3], es[4]]
-
-@test collect(in_neighbors(vs[1], egu)) == [vs[2], vs[3]]
-@test collect(in_neighbors(vs[2], egu)) == [vs[1], vs[4]]
-@test collect(in_neighbors(vs[3], egu)) == [vs[1], vs[4]]
-@test collect(in_neighbors(vs[4], egu)) == [vs[2], vs[3]]
-
 
 #################################################
 #

--- a/test/inclist.jl
+++ b/test/inclist.jl
@@ -132,28 +132,29 @@ add_edge!(gu, 4, 5)
 #
 #################################################
 let
-	g = inclist(KeyVertex{ASCIIString})
+	for g in [inclist(KeyVertex{ASCIIString}), inclist(ASCIIString)]
 
-	vs = [ add_vertex!(g, "a"), add_vertex!(g, "b"), add_vertex!(g, "c") ]
+	    vs = [ add_vertex!(g, "a"), add_vertex!(g, "b"), add_vertex!(g, "c") ]
 
-	@test num_vertices(g) == 3
+	    @test num_vertices(g) == 3
 
-	for i = 1 : 3
-	    @test vertices(g)[i] == vs[i]
-	    @test out_degree(vs[i], g) == 0
-	end
+	    for i = 1 : 3
+	        @test vertices(g)[i] == vs[i]
+	        @test out_degree(vs[i], g) == 0
+	    end
 
-	add_edge!(g, vs[1], vs[2])
-	add_edge!(g, vs[1], vs[3])
-	add_edge!(g, vs[2], vs[3])
+	    add_edge!(g, vs[1], vs[2])
+	    add_edge!(g, vs[1], vs[3])
+	    add_edge!(g, vs[2], vs[3])
 
-	@test out_degree(vs[1], g) == 2
-	@test out_degree(vs[2], g) == 1
-	@test out_degree(vs[3], g) == 0
+	    @test out_degree(vs[1], g) == 2
+	    @test out_degree(vs[2], g) == 1
+	    @test out_degree(vs[3], g) == 0
 
-	@test out_edges(vs[1], g) == [Edge(1, vs[1], vs[2]), Edge(2, vs[1], vs[3])]
-	@test out_edges(vs[2], g) == [Edge(3, vs[2], vs[3])]
-	@test isempty(out_edges(vs[3], g))
+	    @test out_edges(vs[1], g) == [Edge(1, vs[1], vs[2]), Edge(2, vs[1], vs[3])]
+	    @test out_edges(vs[2], g) == [Edge(3, vs[2], vs[3])]
+	    @test isempty(out_edges(vs[3], g))
+        end
 end
 
 let


### PR DESCRIPTION
- As noted in #105, before this PR, vertices really only
  could be Integers (including Char), KeyVertex, or ExVertex,
  mostly because of explicit calls to vertex_index(v).
- This PR changes most calls of vertex_index(v) to
  vertex_index(v,g), and makes sure to only call
  vertex_index(v) for types that it is defined for
- Also provides a slow fallback vertex_index(v,g) for
  non-provided vertex types when the graph's vertex list
  is an AbstractArray.
- Tests also included

Note that the bulk of the change is indentation in the tests.
