### PR TITLE
helper for shortest paths with default edge weights=1

### DIFF
--- a/doc/source/algorithms.rst
+++ b/doc/source/algorithms.rst
@@ -123,7 +123,10 @@ Dijkstra's Algorithm
     :returns:           An instance of ``DijkstraStates`` that encapsulates the results.
     
 Here, ``graph`` can be directed or undirected. It must implement
-``vertex_map``, ``edge_map`` and ``incidence_list``. The following is an example that shows how to use this function:
+``vertex_map``, ``edge_map`` and ``incidence_list``. `edge_dists` is optional; if not specified, 
+default distances of `1` are used for each edge.
+
+The following is an example that shows how to use this function:
 
 .. code-block:: python
 

--- a/src/dijkstra_spath.jl
+++ b/src/dijkstra_spath.jl
@@ -243,3 +243,7 @@ function dijkstra_shortest_paths_withlog{V,D}(
     graph::AbstractGraph{V}, edge_dists::Vector{D}, sources::AbstractVector{V})
     dijkstra_shortest_paths(graph, edge_dists, sources, visitor=LogDijkstraVisitor(STDOUT))
 end
+
+dijkstra_shortest_paths{V}(
+    graph::AbstractGraph{V}, s::V
+) = dijkstra_shortest_paths(graph, ones(num_vertices(graph)), s)


### PR DESCRIPTION
Added a method that takes graph and source, and sets all edge weights to 1. (Purely a convenience method.)
