### PR TITLE
fixed indexing issue when vertices are <:Integer

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -8,8 +8,6 @@ typealias AttributeDict Dict{UTF8String, Any}
 #
 ################################################
 
-vertex_index(v::Integer) = v
-
 immutable KeyVertex{K}
     index::Int
     key::K

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -55,6 +55,7 @@ vertices(g::GenericGraph) = g.vertices
 num_edges(g::GenericGraph) = length(g.edges)
 edges(g::GenericGraph) = g.edges
 
+vertex_index(v::Integer, g::SimpleGraph) = (v <= g.vertices[end]? v: 0)
 vertex_index{V<:ProvidedVertexType}(v::V, g::GenericGraph{V}) = vertex_index(v,vertices(g))
 edge_index{V,E}(e::E, g::GenericGraph{V,E}) = edge_index(e)
 
@@ -68,6 +69,16 @@ in_neighbors{V}(v::V, g::GenericGraph{V}) = SourceIterator(g, in_edges(v, g))
 
 
 # mutation
+
+function add_vertex!(g::SimpleGraph)
+    v = g.vertices[end] + 1
+    g.vertices = 1:v
+    push!(g.finclist, Int[])
+    push!(g.binclist, Int[])
+    v
+end
+
+@deprecate add_vertex!(g::SimpleGraph,v) add_vertex!(g::SimpleGraph)
 
 function add_vertex!{V}(g::GenericGraph{V}, v::V)
     push!(g.vertices, v)

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -56,7 +56,15 @@ num_edges(g::GenericGraph) = length(g.edges)
 edges(g::GenericGraph) = g.edges
 
 vertex_index(v::Integer, g::SimpleGraph) = (v <= g.vertices[end]? v: 0)
-vertex_index{V<:ProvidedVertexType}(v::V, g::GenericGraph{V}) = vertex_index(v,vertices(g))
+
+function vertex_index{V<:ProvidedVertexType}(v::V, g::GenericGraph{V})
+    if applicable(vertex_index, v)  # use O(1) if possible
+        return vertex_index(v)
+    else                            # use O(n)
+        return vertex_index(v,vertices(g))
+    end
+end
+
 edge_index{V,E}(e::E, g::GenericGraph{V,E}) = edge_index(e)
 
 out_edges{V}(v::V, g::GenericGraph{V}) = g.finclist[vertex_index(v, g)]
@@ -71,6 +79,7 @@ in_neighbors{V}(v::V, g::GenericGraph{V}) = SourceIterator(g, in_edges(v, g))
 # mutation
 
 function add_vertex!(g::SimpleGraph)
+    # ensure SimpleGraph indices are consecutive, allowing O(1) indexing
     v = g.vertices[end] + 1
     g.vertices = 1:v
     push!(g.finclist, Int[])

--- a/src/graph.jl
+++ b/src/graph.jl
@@ -55,7 +55,7 @@ vertices(g::GenericGraph) = g.vertices
 num_edges(g::GenericGraph) = length(g.edges)
 edges(g::GenericGraph) = g.edges
 
-vertex_index{V<:ProvidedVertexType}(v::V, g::GenericGraph{V}) = vertex_index(v)
+vertex_index{V<:ProvidedVertexType}(v::V, g::GenericGraph{V}) = vertex_index(v,vertices(g))
 edge_index{V,E}(e::E, g::GenericGraph{V,E}) = edge_index(e)
 
 out_edges{V}(v::V, g::GenericGraph{V}) = g.finclist[vertex_index(v, g)]


### PR DESCRIPTION
Fixes https://github.com/JuliaLang/Graphs.jl/issues/131. This was a simple change, but may have memory implications, as it's enumerating the vertices. Tests on graphs with order=1e7 don't show any appreciable slowdown, though.
