### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/dot.jl
+++ b/src/dot.jl
@@ -73,7 +73,7 @@ function edge_op(graph::AbstractGraph)
 end
 
 function plot(g::AbstractGraph)
-    stdin, proc = writesto(`neato -Tx11`)
+    stdin, proc = open(`neato -Tx11`, 'w')
     to_dot(g, stdin)
     close(stdin)
 end

--- a/src/dot.jl
+++ b/src/dot.jl
@@ -73,7 +73,7 @@ function edge_op(graph::AbstractGraph)
 end
 
 function plot(g::AbstractGraph)
-    stdin, proc = open(`neato -Tx11`, 'w')
+    stdin, proc = open(`neato -Tx11`, "w")
     to_dot(g, stdin)
     close(stdin)
 end


### PR DESCRIPTION
To quote Julia:

```
WARNING: writesto(cmd,args...) is deprecated, use open(cmd,"w",args...) instead.
 in plot at /media/ryan/stuff/.julia/v0.4/Graphs/src/dot.jl:76
 in include at ./boot.jl:242
 in include_from_node1 at loading.jl:128
 in process_options at ./client.jl:300
 in _start at ./client.jl:382
 in _start_3B_4033 at /media/ryan/stuff/julia/usr/bin/../lib/julia/sys.so
```
