### PR TITLE
Emergency bugfix in dsp

### DIFF
--- a/src/dijkstra_spath.jl
+++ b/src/dijkstra_spath.jl
@@ -252,7 +252,7 @@ end
 
 dijkstra_shortest_paths{V}(
     graph::AbstractGraph{V}, s::V
-) = dijkstra_shortest_paths(graph, ones(num_vertices(graph)), s)
+) = dijkstra_shortest_paths(graph, ones(num_edges(graph)), s)
 
 function dijkstra_shortest_paths_explicit{V}(g::AbstractGraph{V},source::V, all...)
     state = dijkstra_shortest_paths(g, source, all...)

--- a/test/dijkstra.jl
+++ b/test/dijkstra.jl
@@ -112,7 +112,7 @@ s2 = dijkstra_shortest_paths(g2, eweights2, [1])
 @test s2.colormap == [2, 2, 2, 2, 2, 2]
 
 g3 = simple_graph(4)
-add_edge!(g3,1,2); add_edge!(g3,1,3); add_edge!(g3,2,3); add_edge!(g3,3,4)
+add_edge!(g3,1,2); add_edge!(g3,1,3); add_edge!(g3,2,3); add_edge!(g3,3,4); add_edge!(g3,4,3); add_edge!(g3,3,1)
 sps = dijkstra_shortest_paths_explicit(g3,2)
-@test length(sps[1]) == 0
+@test length(sps[1]) == 3
 @test sps[4][2] == 3


### PR DESCRIPTION
weights are by edge, not by vertex, so the `dijkstra_shortest_paths` convenience function should have weights corresponding to `num_edges`.
