### PR TITLE
Implemented linear time graph construction method for GenericGraph.

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -3,13 +3,13 @@
 # It implements edge_list, adjacency_list and incidence_list
 #
 
-type GenericGraph{V,E,VList,EList,IncList,VDict} <: AbstractGraph{V,E}
+type GenericGraph{V,E,VList,EList,IncList} <: AbstractGraph{V,E}
     is_directed::Bool
     vertices::VList     # an indexable container of vertices
     edges::EList        # an indexable container of edges
     finclist::IncList   # forward incidence list
     binclist::IncList   # backward incidence list
-    indexof::VDict   # dictionary storing index for each vertex
+    indexof::Dict{V,Int}   # dictionary storing index for each vertex
 end
 
 @graph_implements GenericGraph vertex_list edge_list vertex_map edge_map
@@ -23,9 +23,9 @@ end
 #   AdjList:    Vector{Vector{Int}}
 #   IncList:    Vector{Vector{IEdge}}
 #
-typealias SimpleGraph GenericGraph{Int,IEdge,Range1{Int},Vector{IEdge},Vector{Vector{IEdge}},Dict{Int,Int}}
+typealias SimpleGraph GenericGraph{Int,IEdge,Range1{Int},Vector{IEdge},Vector{Vector{IEdge}}}
 
-typealias Graph{V,E} GenericGraph{V,E,Vector{V},Vector{E},Vector{Vector{E}},Dict{V,Int}}
+typealias Graph{V,E} GenericGraph{V,E,Vector{V},Vector{E},Vector{Vector{E}}}
 
 # construction
 

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -267,3 +267,47 @@ e = [ExEdge(1,v[1],v[2])]
 g = graph(v,e,is_directed=true)
 @test num_edges(g) == 1
 @test num_vertices(g) == 2
+
+# Integer vertices and edges
+n = 100
+m = 1000
+vs = rand(1:10*n,n)
+es = Edge{Int}[]
+for i in 1:m
+  push!(es,Edge(i,vs[rand(1:n,1)[1]],vs[rand(1:n,1)[1]]))
+end
+g = graph(vs,es)
+for i in 1:m
+  add_edge!(g,vs[rand(1:n,1)[1]],vs[rand(1:n,1)[1]])
+end
+
+@test num_vertices(g) == n
+@test num_edges(g) == 2 * m
+for v in vs
+  @test vertex_index(v,g) == g.indexof[v]
+end
+for i in 1:m
+  @test edge_index(es[i],g) == i
+end
+
+# same for undirected graph
+n = 100
+m = 1000
+vs = rand(1:10*n,n)
+es = Edge{Int}[]
+for i in 1:m
+  push!(es,Edge(i,vs[rand(1:n,1)[1]],vs[rand(1:n,1)[1]]))
+end
+g = graph(vs,es,is_directed=false)
+for i in 1:m
+  add_edge!(g,vs[rand(1:n,1)[1]],vs[rand(1:n,1)[1]])
+end
+
+@test num_vertices(g) == n
+@test num_edges(g) == 2 * m
+for v in vs
+  @test vertex_index(v,g) == g.indexof[v]
+end
+for i in 1:m
+  @test edge_index(es[i],g) == i
+end


### PR DESCRIPTION
See issue #160 for background.

I introduced a new field in the GenericGraph data type called `indexof` which
is a dictionary mapping V to Int. It gives a quick way to look up the index of
a vertex when encountering a new edge. The hash table look up occurs in
`vertex_index`.

I added corresponding test cases in ../test/graph.jl.
