### PR TITLE
fixed vertex adding to simple_graph(0)

### DIFF
--- a/src/graph.jl
+++ b/src/graph.jl
@@ -81,7 +81,7 @@ in_neighbors{V}(v::V, g::GenericGraph{V}) = SourceIterator(g, in_edges(v, g))
 
 function add_vertex!(g::SimpleGraph)
     # ensure SimpleGraph indices are consecutive, allowing O(1) indexing
-    v = g.vertices[end] + 1
+    v = length(g.vertices)+1
     g.vertices = 1:v
     push!(g.finclist, Int[])
     push!(g.binclist, Int[])

--- a/test/graph.jl
+++ b/test/graph.jl
@@ -80,6 +80,11 @@ es = [  add_edge!(sgd, 1, 2)
 
 
 @test collect_edges(sgd) == [Edge(1,1,2), Edge(2,1,3), Edge(3,2,4), Edge(4,3,4)]
+
+sgd = simple_graph(0)
+v = add_vertex!(sgd)
+@test v == 1
+
 #################################################
 #
 #  SimpleUndirectedGraph


### PR DESCRIPTION
Graphs.jl currently does not allow adding of vertices to SimpleGraphs initialized with 0 vertices (empty vertex list). Here's a fix for that + a trivial test case in graphs.jl
