### PR TITLE
Fixed the lack of default AttributeDict argument in to_dot

### DIFF
--- a/src/dot.jl
+++ b/src/dot.jl
@@ -18,7 +18,7 @@ function to_dot(graph::AbstractGraph, attrs::AttributeDict=AttributeDict())
 end
 
 # Write the dot representation of a graph to a stream.
-function to_dot{G<:AbstractGraph}(graph::G, stream::IO,attrs::AttributeDict)
+function to_dot{G<:AbstractGraph}(graph::G, stream::IO,attrs::AttributeDict=AttributeDict())
     has_vertex_attrs = method_exists(attributes, (vertex_type(graph), G))
     has_edge_attrs = method_exists(attributes, (edge_type(graph), G))
 


### PR DESCRIPTION
Lack of default attributes causes errors on calls without explicit AttributeDict passed, thus making plot() for graphs unusable
