### PR TITLE
Update connected_components.jl

### DIFF
--- a/src/connected_components.jl
+++ b/src/connected_components.jl
@@ -109,7 +109,7 @@ function discover_vertex!(vis::TarjanVisitor, v)
 end
 
 function examine_neighbor!(vis::TarjanVisitor, v, w, w_color::Int, e_color::Int)
-    if w_color == 1 # 1 means added seen, but not explored
+    if w_color > 0 # if we've seen this vertex already
         while vis.index[vertex_index(w, vis.graph)] < vis.lowlink[end]
             pop!(vis.lowlink)
         end

--- a/src/connected_components.jl
+++ b/src/connected_components.jl
@@ -110,7 +110,7 @@ end
 
 function examine_neighbor!(vis::TarjanVisitor, v, w, w_color::Int, e_color::Int)
     if w_color > 0 # if we've seen this vertex already
-        vi = vis.index[vertex-index(w, vis.graph)]
+        vi = vis.index[vertex_index(w, vis.graph)]
         while vi > 0 && vi < vis.lowlink[end]
             pop!(vis.lowlink)
         end

--- a/src/connected_components.jl
+++ b/src/connected_components.jl
@@ -110,7 +110,8 @@ end
 
 function examine_neighbor!(vis::TarjanVisitor, v, w, w_color::Int, e_color::Int)
     if w_color > 0 # if we've seen this vertex already
-        while vis.index[vertex_index(w, vis.graph)] < vis.lowlink[end]
+        vi = vis.index[vertex-index(w, vis.graph)]
+        while vi > 0 && vi < vis.lowlink[end]
             pop!(vis.lowlink)
         end
     end


### PR DESCRIPTION
This fixes the bug in #187. It seems appropriate to check for `w_color > 0` instead of `==1` since it shouldn't matter here that the vertex hasn't been explored. We're doing a dfs for each vertex whose colormap !=0 in any case.

That said, I'm not really an expert in Tarjan's algorithm, so please review it :)
