### PR TITLE
Import < from Base and remove white spaces in method declarations.

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -1,7 +1,7 @@
 module Graphs
 using DataStructures, Compat
 
-import Base: start, done, next, show, ==
+import Base: start, done, next, show, ==, <
 import Base: length, isempty, size, getindex, isless
 
 export

--- a/src/dijkstra_spath.jl
+++ b/src/dijkstra_spath.jl
@@ -20,7 +20,7 @@ immutable DijkstraHEntry{V,D}
     dist::D
 end
 
-< (e1::DijkstraHEntry, e2::DijkstraHEntry) = e1.dist < e2.dist
+<(e1::DijkstraHEntry, e2::DijkstraHEntry) = e1.dist < e2.dist
 
 # create Dijkstra states
 

--- a/src/dot.jl
+++ b/src/dot.jl
@@ -63,7 +63,7 @@ function to_dot(attrs::AttributeDict)
     if isempty(attrs)
         ""
     else
-        string("[",join(map(to_dot,collect(attrs)),","),"]")
+        string("[",join(map(a -> to_dot(a[1], a[2]), attrs),","),"]")
     end
 end
 # write a graph wide attributes example: size = "4,4";
@@ -71,9 +71,11 @@ function to_dot_graph(attrs::AttributeDict)
     if isempty(attrs)
         ""
     else
-        string(join(map(to_dot, collect(attrs)),";\n"),";\n")
+        string(join(map(a -> to_dot(a[1], a[2]), attrs),";\n"),";\n")
     end
 end
+
+to_dot(attr::String, value) = "\"$attr\"=\"$value\""
 
 to_dot(attr_tuple::@compat Tuple{UTF8String, Any}) = "\"$(attr_tuple[1])\"=\"$(attr_tuple[2])\""
 

--- a/src/prim_mst.jl
+++ b/src/prim_mst.jl
@@ -21,7 +21,7 @@ immutable PrimHEntry{V,E,W}
     weight::W
 end
 
-< (e1::PrimHEntry, e2::PrimHEntry) = e1.weight < e2.weight
+<(e1::PrimHEntry, e2::PrimHEntry) = e1.weight < e2.weight
 
 # create Prim states
 


### PR DESCRIPTION
This PR is to eliminate the warnings being generated in julia 0.4.
