### PR TITLE
fix test failures and dep warns in 0.4.0-rc1

### DIFF
--- a/src/dot.jl
+++ b/src/dot.jl
@@ -78,6 +78,7 @@ end
 to_dot(attr::String, value) = "\"$attr\"=\"$value\""
 
 to_dot(attr_tuple::@compat Tuple{UTF8String, Any}) = "\"$(attr_tuple[1])\"=\"$(attr_tuple[2])\""
+to_dot(attr_pair::Pair{UTF8String,Any}) = "\"$(attr_pair[1])\"=\"$(attr_pair[2])\""
 
 function graph_type_string(graph::AbstractGraph)
     is_directed(graph) ? "digraph" : "graph"


### PR DESCRIPTION
I get test failures on rc1, this fixes it. I had also included fixes for the deprecation warnings, but I guess those are already in master, but not tagged?

Without this I get:

```
julia> Pkg.test("Graphs")
INFO: Testing Graphs
running /Users/oneilg/.julia/v0.4/Graphs/test/edgelist.jl ...

WARNING: deprecated syntax "< (" at /Users/oneilg/.julia/v0.4/Graphs/src/dijkstra_spath.jl:23.
Use "<(" instead.
WARNING: module Graphs should explicitly import < from Base

WARNING: deprecated syntax "< (" at /Users/oneilg/.julia/v0.4/Graphs/src/prim_mst.jl:24.
Use "<(" instead.
running /Users/oneilg/.julia/v0.4/Graphs/test/adjlist.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/bellman_test.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/inclist.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/graph.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/gmatrix.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/bfs.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/dfs.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/conn_comp.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/dijkstra.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/a_star_spath.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/mst.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/floyd.jl ...
running /Users/oneilg/.julia/v0.4/Graphs/test/dot.jl ...
ERROR: LoadError: LoadError: test error in expression: to_dot(attrs) == "[\"foo\"=\"bar\"]"
MethodError: `to_dot` has no method matching to_dot(::Pair{UTF8String,Any})
```
