### PR TITLE
Julia 0.4 compatibility updates.

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -22,14 +22,14 @@ type ExVertex
     label::UTF8String
     attributes::AttributeDict
 
-    ExVertex(i::Int, label::String) = new(i, label, AttributeDict())
+    ExVertex(i::Int, label::AbstractString) = new(i, label, AttributeDict())
 end
 
-make_vertex(g::AbstractGraph{ExVertex}, label::String) = ExVertex(num_vertices(g) + 1, utf8(label))
+make_vertex(g::AbstractGraph{ExVertex}, label::AbstractString) = ExVertex(num_vertices(g) + 1, utf8(label))
 vertex_index(v::ExVertex) = v.index
 attributes(v::ExVertex, g::AbstractGraph) = v.attributes
 
-typealias ProvidedVertexType Union(KeyVertex, ExVertex)
+typealias ProvidedVertexType @compat(Union{KeyVertex, ExVertex})
 
 vertex_index{V<:ProvidedVertexType}(v::V, g::AbstractGraph{V}) = vertex_index(v)
 

--- a/src/dot.jl
+++ b/src/dot.jl
@@ -4,7 +4,7 @@
 # http://www.graphviz.org/pub/scm/graphviz2/doc/info/lang.html
 
 # Write the dot representation of a graph to a file by name.
-function to_dot(graph::AbstractGraph, filename::String,attrs::AttributeDict=AttributeDict())
+function to_dot(graph::AbstractGraph, filename::AbstractString, attrs::AttributeDict=AttributeDict())
     open(filename,"w") do f
         to_dot(graph, f, attrs)
     end
@@ -75,7 +75,7 @@ function to_dot_graph(attrs::AttributeDict)
     end
 end
 
-to_dot(attr::String, value) = "\"$attr\"=\"$value\""
+to_dot(attr::AbstractString, value) = "\"$attr\"=\"$value\""
 
 to_dot(attr_tuple::@compat Tuple{UTF8String, Any}) = "\"$(attr_tuple[1])\"=\"$(attr_tuple[2])\""
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -8,7 +8,7 @@ function show(io::IO, v::ExVertex)
     end
 end
 
-function show(io::IO, e::Union(Edge, ExEdge))
+function show(io::IO, e::@compat(Union{Edge, ExEdge}))
     print(io, "edge [$(e.index)]: $(e.source) -- $(e.target)")
 end
 


### PR DESCRIPTION
The following changes were made to address deprecated warnings in julia 0.4.  These rely on the Compat package to maintain backward compatibility.

String -> AbstractString
Union() -> Union{}
