### PR TITLE
Add Travis testing against both Julia 0.3 and 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
     - linux
     - osx
 julia:
-    - release
+    - 0.3
+    - 0.4
     - nightly
 notifications:
     email: false

--- a/test/dot2.jl
+++ b/test/dot2.jl
@@ -89,7 +89,7 @@ end # module testDOT1
 
 module testDOT2
 
-using Graphs
+using Graphs, Compat
 using Base.Test
 
 ###########


### PR DESCRIPTION
0.3 is still supported according to REQUIRE, so should still be tested
