### PR TITLE
Implement dicts and fix shortest_path bug

### DIFF
--- a/src/Graphs.jl
+++ b/src/Graphs.jl
@@ -48,6 +48,9 @@ export
     GenericIncidenceList, SimpleIncidenceList, VectorIncidenceList, IncidenceList,
     simple_inclist, inclist,
 
+    # dict based graphs
+    IncidenceDict, incdict,
+
     # graph
     GenericGraph, SimpleGraph, Graph, simple_graph, graph,
 

--- a/src/gmatrix.jl
+++ b/src/gmatrix.jl
@@ -33,8 +33,8 @@ function matrix_from_adjpairs!(a::AbstractMatrix, g::AbstractGraph, gen; returnp
         tempd = Dict{Int,Int}()
         verts = vertices(g)
         for i in 1:length(verts)
-          p[i] = verts[i].index
-          tempd[verts[i].index] = i
+          p[i] = vertex_index(verts[i], g)
+          tempd[p[i]] = i
         end
         i = 0
         for u in verts

--- a/src/gmatrix.jl
+++ b/src/gmatrix.jl
@@ -4,9 +4,9 @@
 #
 ###########################################################
 
-function matrix_from_adjpairs!(a::AbstractMatrix, g::AbstractGraph, gen)
+function matrix_from_adjpairs!(a::AbstractMatrix, g::AbstractGraph, gen; returnpermutation::Bool=false)
     @graph_requires g vertex_list vertex_map
-
+    p = nothing
     if implements_edge_list(g)
         if is_directed(g)
             for e in edges(g)
@@ -29,23 +29,32 @@ function matrix_from_adjpairs!(a::AbstractMatrix, g::AbstractGraph, gen)
         end
 
     elseif implements_adjacency_list(g)
-        for u in vertices(g)
+        p = zeros(Int64,size(a,1))
+        tempd = Dict{Int,Int}()
+        verts = vertices(g)
+        for i in 1:length(verts)
+          p[i] = verts[i].index
+          tempd[verts[i].index] = i
+        end
+        i = 0
+        for u in verts
+            i+=1
             ui = vertex_index(u, g)
             for v in out_neighbors(u, g)
                 vi = vertex_index(v, g)
                 val = get(gen, g, u, v)
-                a[ui, vi] = val
+                a[i, tempd[vi]] = val # p[i] -> ui, tempd[vi]->i
             end
         end
     else
         error("g does not implement required interface.")
     end
 
-    return a
+    return returnpermutation ? (a, p) : a
 end
 
-matrix_from_adjpairs(g::AbstractGraph, gen) =
-    (n = num_vertices(g); matrix_from_adjpairs!(zeros(eltype(gen), n, n), g, gen))
+matrix_from_adjpairs(g::AbstractGraph, gen; returnpermutation::Bool=false) =
+    (n = num_vertices(g); matrix_from_adjpairs!(zeros(eltype(gen), n, n), g, gen, returnpermutation=returnpermutation))
 
 
 function sparse_matrix_from_adjpairs(g::AbstractGraph, gen)
@@ -238,8 +247,8 @@ type _GenUnit{T} end
 Base.get{T,V}(::_GenUnit{T}, g::AbstractGraph{V}, u::V, v::V) = one(T)
 Base.eltype{T}(::_GenUnit{T}) = T
 
-adjacency_matrix{T<:Number}(g::AbstractGraph, ::Type{T}) = matrix_from_adjpairs(g, _GenUnit{T}())
-adjacency_matrix(g::AbstractGraph) = adjacency_matrix(g, Bool)
+adjacency_matrix{T<:Number}(g::AbstractGraph, ::Type{T}; returnpermutation::Bool=false) = matrix_from_adjpairs(g, _GenUnit{T}(), returnpermutation=returnpermutation)
+adjacency_matrix(g::AbstractGraph; returnpermutation::Bool=false) = adjacency_matrix(g, Bool, returnpermutation=returnpermutation)
 
 adjacency_matrix_sparse{T<:Number}(g::AbstractGraph, ::Type{T}) = sparse_matrix_from_adjpairs(g, _GenUnit{T}())
 adjacency_matrix_sparse(g::AbstractGraph) = adjacency_matrix_sparse(g, Bool)

--- a/src/incidence_list.jl
+++ b/src/incidence_list.jl
@@ -48,6 +48,7 @@ num_vertices(g::GenericIncidenceList) = length(g.vertices)
 # vertices(g::GenericIncidenceList) = g.vertices
 
 # dictionary enables version
+vertices_specific(a::UnitRange{Int64}) = a
 vertices_specific{V}(a::Vector{V}) = a
 vertices_specific{V}(d::Dict{Int64,V}) = collect(values(d))
 vertices(g::GenericIncidenceList) = vertices_specific(g.vertices)

--- a/src/incidence_list.jl
+++ b/src/incidence_list.jl
@@ -33,11 +33,11 @@ inclist{V,E}(::Type{V}, ::Type{E}; is_directed::Bool = true) = inclist(V[], E; i
 inclist{V}(vs::Vector{V}; is_directed::Bool = true) = inclist(vs, Edge{V}; is_directed=is_directed)
 inclist{V}(::Type{V}; is_directed::Bool = true) = inclist(V[], Edge{V}; is_directed=is_directed)
 
-# starting work on Dict version
+# First constructors on Dict Inc List version (reusing GenericIncidenceList container and functions, few dispatch changes required)
 typealias IncidenceDict{V,E} GenericIncidenceList{V, E, Dict{Int64,V}, Dict{Int64,Vector{E}}}
 incdict{V,E}(vs::Dict{Int64,V}, ::Type{E}; is_directed::Bool = true) =
     IncidenceDict{V,E}(is_directed, vs, 0, Dict{Int64, E}())
-incdict{V}(vs::Dict{Int64,V}; is_directed::Bool = true) = incdict(vs, Edge{V}; is_directed=is_directed)
+incdict{V}(::Type{V}; is_directed::Bool = true) = incdict(Dict{Int64,V}(), Edge{V}; is_directed=is_directed)
 
 
 # required interfaces


### PR DESCRIPTION
Hi, I'm using Graphs.ExVertex type and found an issue with shortest_path. Similar to [issue/#137](https://github.com/JuliaLang/Graphs.jl/issues/137). Please find my fix for this here -- basically there was a case where shortest_path(...) wrongly assumed indexes were available.

cc @scidom @sbromberger @mlubin  
