### PR TITLE
Update Documentation

### DIFF
--- a/doc/source/graphs.rst
+++ b/doc/source/graphs.rst
@@ -374,7 +374,7 @@ Specifically, it implements the following methods:
     
 .. py:function:: out_edges(v, g)
 
-    returns the number of outgoing edges from vertex ``v`` in graph ``g``.
+    returns the outgoing edges from vertex ``v`` in graph ``g``.
     
 .. py:function:: out_neighbors(v, g)
 


### PR DESCRIPTION
out_edges actually returns the edge of type E if the graph is defined over vertices of type V and edges of type E.