### PR TITLE
Update common.jl

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -82,6 +82,7 @@ end
 ExEdge{V}(i::Int, s::V, t::V) = ExEdge{V}(i, s, t, AttributeDict())
 ExEdge{V}(i::Int, s::V, t::V, attrs::AttributeDict) = ExEdge{V}(i, s, t, attrs)
 make_edge{V}(g::AbstractGraph{V}, s::V, t::V) = ExEdge(num_edges(g) + 1, s, t)
+make_edge{V}(g::AbstractGraph{V}, s::V, t::V, dict::AttributeDict) = ExEdge(num_edges(g) + 1, s, t, dict)
 
 revedge{V}(e::ExEdge{V}) = ExEdge{V}(e.index, e.target, e.source, e.attributes)
 


### PR DESCRIPTION
A constructor for ExEdge that takes an additional parameter is a useful extension that makes a lot of sense because the ExEdge typed is implemented *specifically* to allow the inclusion of AttritubeDict (s) in addition to the source and target of the edge. A complementary change I'm submitting in the corresponding file is an version of the add_edge! function that makes use of this.